### PR TITLE
Add metadata query comand for client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -170,13 +170,12 @@ var queryCmd = &cobra.Command{
 }
 
 var metadataCmd = &cobra.Command{
-	Use:   "metadata start end [public key(base64)] [type(max 20 bytes)]",
-	Args:  cobra.RangeArgs(2, 4),
+	Use:   "metadata start end",
+	Args:  cobra.ExactArgs(2),
 	Short: "Query DB for metadata",
 	Long: `Query DB for metadata.
-'start' and 'end' is essential. 'public key' and 'type' is optional.
-If you want to query for specific type for all users, pass public key
-argument as 'none'.`,
+'start' and 'end' are essential. '-p' and '-t' flags are optional.
+If you want to query for only one timestamp, make 'start' and 'end' equal.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		start, err := strconv.ParseInt(args[0], 0, 64)
 		if err != nil {
@@ -191,16 +190,8 @@ argument as 'none'.`,
 		}
 
 		client := NewClient("http://localhost:26657")
-		if len(args) == 2 {
-			client.ReadMetaData(start, end, "", "")
-		} else if len(args) == 3 {
-			client.ReadMetaData(start, end, args[2], "")
-		} else if args[2] == "none" {
-			client.ReadMetaData(start, end, "", args[3])
-		} else {
-			client.ReadMetaData(start, end, args[2], args[3])
-		}
 
+		client.ReadMetaData(start, end, pubKey, dataType)
 	},
 }
 
@@ -214,4 +205,6 @@ func init() {
 	Cmd.AddCommand(generateCmd)
 	Cmd.AddCommand(queryCmd)
 	queryCmd.AddCommand(metadataCmd)
+	metadataCmd.Flags().StringVarP(&pubKey, "pubkey", "p", "", "user's public key (base64)")
+	metadataCmd.Flags().StringVarP(&dataType, "type", "t", "", "data type (max 20 bytes)")
 }

--- a/libs/db/c_rocks_db.go
+++ b/libs/db/c_rocks_db.go
@@ -192,12 +192,6 @@ func (db *CRocksDB) NewBatch() Batch {
 	return &cRocksDBBatch{db, batch}
 }
 
-
-type cRocksDBBatch struct {
-	db    *CRocksDB
-	batch *gorocksdb.WriteBatch
-}
-
 // Implements Batch.
 func (mBatch *cRocksDBBatch) Set(key, value []byte) {
 	mBatch.batch.Put(key, value)
@@ -373,4 +367,3 @@ func (db *CRocksDB) WriteOption() *gorocksdb.WriteOptions {
 func (db *CRocksDB) ReadOption() *gorocksdb.ReadOptions {
 	return db.ro
 }
-

--- a/master/MasterApplication.go
+++ b/master/MasterApplication.go
@@ -72,7 +72,7 @@ func (app *MasterApplication) DeliverTx(tx []byte) abciTypes.ResponseDeliverTx {
 	var dataSlice = types.DataSlice{}
 	err := json.Unmarshal(tx, &dataSlice)
 	if err != nil {
-		fmt.Println("dataSlice Unmarshal error",err)
+		fmt.Println("dataSlice Unmarshal error", err)
 	}
 
 	for i := 0; i < len(dataSlice); i++ {

--- a/types/types.go
+++ b/types/types.go
@@ -61,4 +61,3 @@ func typeToByteArr(dType string) []byte {
 
 	return ret
 }
-


### PR DESCRIPTION
**Reference**
#27 #22 

**구현사항**
* metadata와 realdata query를 위한 DataQuery struct 추가
* Client에 start와 end사이 데이터들의 metadata를 read하는 metadata query command 추가