### PR TITLE
Change data attribute name from type to qualifier

### DIFF
--- a/client/client_read_test.go
+++ b/client/client_read_test.go
@@ -18,7 +18,7 @@ func (suite *ClientTestSuite) TestClient_ReadData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Type: TestDataType, Data: data}})
+	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	c := rpcClient.NewLocal(node)
@@ -30,7 +30,7 @@ func (suite *ClientTestSuite) TestClient_ReadData() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.ReadData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestDataType)
+	res, err := suite.dbClient.ReadData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestQualifier)
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(tx, qres.Value)
@@ -45,9 +45,9 @@ func (suite *ClientTestSuite) TestClient_ReadMetaData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Type: TestDataType, Data: data}})
+	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
-	expectedValue, err := json.Marshal(types.MetaResponseSlice{types.MetaResponse{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Type: TestDataType}})
+	expectedValue, err := json.Marshal(types.MetaResponseSlice{types.MetaResponse{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	c := rpcClient.NewLocal(node)
@@ -59,7 +59,7 @@ func (suite *ClientTestSuite) TestClient_ReadMetaData() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.ReadMetaData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestDataType)
+	res, err := suite.dbClient.ReadMetaData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestQualifier)
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(expectedValue, qres.Value)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,8 +15,8 @@ var node *nm.Node
 var testDir string
 
 const (
-	TestPubKey   = "Pe8PPI4Mq7kJIjDJjffoTl6s5EezGQSyIcu5Y2KYDaE="
-	TestDataType = "testType"
+	TestPubKey    = "Pe8PPI4Mq7kJIjDJjffoTl6s5EezGQSyIcu5Y2KYDaE="
+	TestQualifier = "testQualifier"
 )
 
 type ClientTestSuite struct {

--- a/client/client_write_test.go
+++ b/client/client_write_test.go
@@ -22,10 +22,10 @@ func (suite *ClientTestSuite) TestClient_WriteData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Type: TestDataType, Data: data}})
+	tx, err := json.Marshal(types.DataSlice{types.Data{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
 
-	bres, err := suite.dbClient.WriteData(time, TestPubKey, TestDataType, data)
+	bres, err := suite.dbClient.WriteData(time, TestPubKey, TestQualifier, data)
 
 	require.Nil(err, "err: %+v", err)
 	require.Equal(bres.Code, abci.CodeTypeOK)

--- a/master/MasterApplication.go
+++ b/master/MasterApplication.go
@@ -78,7 +78,7 @@ func (app *MasterApplication) DeliverTx(tx []byte) abciTypes.ResponseDeliverTx {
 	for i := 0; i < len(dataSlice); i++ {
 		var metaData = &types.MetaData{}
 		metaData.UserKey = dataSlice[i].UserKey
-		metaData.Type = dataSlice[i].Type
+		metaData.Qualifier = dataSlice[i].Qualifier
 		metaByte, err := json.Marshal(metaData)
 		if err != nil {
 			fmt.Println("meta 변환 error : ", err)

--- a/test/writeFile.json
+++ b/test/writeFile.json
@@ -1,5 +1,5 @@
 [
-        {"timestamp":1544772882435375000,"userKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","type":"cpu","data":"YWJj"},
-        {"timestamp":1544772960049177000,"userKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","type":"mem","data":"ZGVm"},
-        {"timestamp":1544772967331458000,"userKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","type":"speed","data":"Z2hp"}
+        {"timestamp":1544772882435375000,"userKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"cpu","data":"YWJj"},
+        {"timestamp":1544772960049177000,"userKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"mem","data":"ZGVm"},
+        {"timestamp":1544772967331458000,"userKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"speed","data":"Z2hp"}
 ]

--- a/types/types.go
+++ b/types/types.go
@@ -8,22 +8,22 @@ type Data struct {
 	//Timestamp는 client에서 nano단위로 들어옴.
 	Timestamp int64  `json:"timestamp"`
 	UserKey   []byte `json:"userKey"`
-	Type      string `json:"type"`
+	Qualifier string `json:"qualifier"`
 	Data      []byte `json:"data"`
 }
 
 type DataSlice []Data
 
 type MetaData struct {
-	UserKey []byte `json:"userKey"`
-	Type    string `json:"type"`
+	UserKey   []byte `json:"userKey"`
+	Qualifier string `json:"qualifier"`
 }
 
 type DataQuery struct {
-	Start   int64  `json:"start"`
-	End     int64  `json:"end"`
-	UserKey []byte `json:"userKey"`
-	Type    string `json:"type"`
+	Start     int64  `json:"start"`
+	End       int64  `json:"end"`
+	UserKey   []byte `json:"userKey"`
+	Qualifier string `json:"qualifier"`
 }
 
 //rowkey = timestamp + userkey + datatype + offset
@@ -31,29 +31,31 @@ func DataKeyToByteArr(data Data) []byte {
 
 	timestamp := make([]byte, 8)
 	binary.BigEndian.PutUint64(timestamp, uint64((data.Timestamp/1000000000)*1000000000))
+	qualifier := make([]byte, 20)
+	qualifier = QualifierToByteArr(data.Qualifier)
 
 	offset := make([]byte, 4)
 	binary.BigEndian.PutUint32(offset, uint32(data.Timestamp%1000000000))
+	rowKey := append(timestamp, data.UserKey...)
+	rowKey = append(rowKey, qualifier...)
 
-	dType := make([]byte, 20)
-	dType = typeToByteArr(data.Type)
-
-	ret := append(timestamp, data.UserKey...)
-	ret = append(ret, dType...)
-	ret = append(ret, offset...)
-
-	return ret
+	return rowKey
 }
 
 //string -> byte with padding
-func typeToByteArr(dType string) []byte {
-	ret := make([]byte, 20)
-	for i := 0; i < len(dType); i++ {
-		ret[i] = dType[i]
+func QualifierToByteArr(qualifier string) []byte {
+	qualifierArr := make([]byte, 20)
+	for i := 0; i < len(qualifier); i++ {
+		qualifierArr[i] = qualifier[i]
 	}
-	for i := len(dType); i < 20; i++ {
-		ret[i] = 0
+	for i := len(qualifier); i < 20; i++ {
+		qualifierArr[i] = 0
 	}
 
-	return ret
+	return qualifierArr
+}
+
+	}
+	}
+
 }


### PR DESCRIPTION
**Reference**
#43 https://github.com/paust-team/paust-db/pull/35#issuecomment-451344099

**내용**
type에서 qualifier로 변경
types/types.go, client/*, master/MasterApplication.go

resolve paust-team/paust-db#43