### PR TITLE
Change timestamp data type from int64 to uint64

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -53,13 +53,13 @@ func (client *Client) WriteData(time time.Time, pubKey string, qualifier string,
 		os.Exit(1)
 	}
 
-	jsonString, _ := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: qualifier, Data: data}})
+	jsonString, _ := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: uint64(time.UnixNano()), UserKey: pubKeyBytes, Qualifier: qualifier, Data: data}})
 
 	bres, err := client.client.BroadcastTxSync(jsonString)
 	return bres, err
 }
 
-func (client *Client) ReadData(start int64, end int64, pubKey string, qualifier string) (*ctypes.ResultABCIQuery, error) {
+func (client *Client) ReadData(start uint64, end uint64, pubKey string, qualifier string) (*ctypes.ResultABCIQuery, error) {
 	var pubKeyBytes []byte
 	if pubKey != "" {
 		var err error
@@ -173,7 +173,7 @@ func (client *Client) WriteStdin() (*ctypes.ResultBroadcastTx, error) {
 	return bres, err
 }
 
-func (client *Client) ReadMetaData(start int64, end int64, pubKey string, qualifier string) (*ctypes.ResultABCIQuery, error) {
+func (client *Client) ReadMetaData(start uint64, end uint64, pubKey string, qualifier string) (*ctypes.ResultABCIQuery, error) {
 	var pubKeyBytes []byte
 	if pubKey != "" {
 		var err error
@@ -312,13 +312,13 @@ var realdataCmd = &cobra.Command{
 'start' and 'end' are essential. '-p' and '-q' flags are optional.
 If you want to query for only one timestamp, make 'start' and 'end' equal.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		start, err := strconv.ParseInt(args[0], 0, 64)
+		start, err := strconv.ParseUint(args[0], 0, 64)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
-		end, err := strconv.ParseInt(args[1], 0, 64)
+		end, err := strconv.ParseUint(args[1], 0, 64)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -349,13 +349,13 @@ var metadataCmd = &cobra.Command{
 'start' and 'end' are essential. '-p' and '-q' flags are optional.
 If you want to query for only one timestamp, make 'start' and 'end' equal.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		start, err := strconv.ParseInt(args[0], 0, 64)
+		start, err := strconv.ParseUint(args[0], 0, 64)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
-		end, err := strconv.ParseInt(args[1], 0, 64)
+		end, err := strconv.ParseUint(args[1], 0, 64)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/client/client_read_test.go
+++ b/client/client_read_test.go
@@ -18,7 +18,7 @@ func (suite *ClientTestSuite) TestClient_ReadData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
+	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: uint64(time.UnixNano()), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	c := rpcClient.NewLocal(node)
@@ -30,7 +30,7 @@ func (suite *ClientTestSuite) TestClient_ReadData() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.ReadData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestQualifier)
+	res, err := suite.dbClient.ReadData(uint64(time.UnixNano()), uint64(time.UnixNano())+1, TestPubKey, TestQualifier)
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(tx, qres.Value)
@@ -45,9 +45,9 @@ func (suite *ClientTestSuite) TestClient_ReadMetaData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
+	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: uint64(time.UnixNano()), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
-	expectedValue, err := json.Marshal(types.MetaResponseSlice{types.MetaResponse{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier}})
+	expectedValue, err := json.Marshal(types.MetaResponseSlice{types.MetaResponse{Timestamp: uint64(time.UnixNano()), UserKey: pubKeyBytes, Qualifier: TestQualifier}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	c := rpcClient.NewLocal(node)
@@ -59,7 +59,7 @@ func (suite *ClientTestSuite) TestClient_ReadMetaData() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.ReadMetaData(time.UnixNano(), time.UnixNano()+1, TestPubKey, TestQualifier)
+	res, err := suite.dbClient.ReadMetaData(uint64(time.UnixNano()), uint64(time.UnixNano())+1, TestPubKey, TestQualifier)
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(expectedValue, qres.Value)

--- a/client/client_write_test.go
+++ b/client/client_write_test.go
@@ -29,7 +29,7 @@ func (suite *ClientTestSuite) TestClient_WriteData() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: time.UnixNano(), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
+	tx, err := json.Marshal(types.RealDataSlice{types.RealData{Timestamp: uint64(time.UnixNano()), UserKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	bres, err := suite.dbClient.WriteData(time, TestPubKey, TestQualifier, data)

--- a/types/types.go
+++ b/types/types.go
@@ -9,7 +9,7 @@ import (
 
 type RealData struct {
 	//Timestamp는 client에서 nano단위로 들어옴.
-	Timestamp int64  `json:"timestamp"`
+	Timestamp uint64 `json:"timestamp"`
 	UserKey   []byte `json:"userKey"`
 	Qualifier string `json:"qualifier"`
 	Data      []byte `json:"data"`
@@ -23,14 +23,14 @@ type MetaData struct {
 }
 
 type DataQuery struct {
-	Start     int64  `json:"start"`
-	End       int64  `json:"end"`
+	Start     uint64 `json:"start"`
+	End       uint64 `json:"end"`
 	UserKey   []byte `json:"userKey"`
 	Qualifier string `json:"qualifier"`
 }
 
 type MetaResponse struct {
-	Timestamp int64  `json:"timestamp"`
+	Timestamp uint64 `json:"timestamp"`
 	UserKey   []byte `json:"userKey"`
 	Qualifier string `json:"qualifier"`
 }
@@ -47,7 +47,7 @@ const (
 func RealDataToRowKey(data RealData) []byte {
 	timestamp := make([]byte, TimeLen)
 	qualifier := make([]byte, QualifierLen)
-	binary.BigEndian.PutUint64(timestamp, uint64(data.Timestamp))
+	binary.BigEndian.PutUint64(timestamp, data.Timestamp)
 	qualifier = QualifierToByteArr(data.Qualifier)
 	rowKey := funk.FlattenDeep([][]byte{timestamp, data.UserKey, qualifier})
 
@@ -76,7 +76,7 @@ func RowKeyAndValueToRealData(key, value []byte) RealData {
 
 	timestamp := binary.BigEndian.Uint64(key[0:TimeLen])
 
-	realData.Timestamp = int64(timestamp)
+	realData.Timestamp = timestamp
 	realData.UserKey = make([]byte, UserKeyLen)
 	copy(realData.UserKey, key[TimeLen:TimeLen+UserKeyLen])
 
@@ -109,7 +109,7 @@ func MetaDataAndKeyToMetaResponse(key []byte, meta MetaData) (MetaResponse, erro
 
 	timestamp := binary.BigEndian.Uint64(key[0:TimeLen])
 
-	metaResponse.Timestamp = int64(timestamp)
+	metaResponse.Timestamp = timestamp
 	metaResponse.UserKey = meta.UserKey
 	metaResponse.Qualifier = meta.Qualifier
 
@@ -122,8 +122,8 @@ func CreateStartByteAndEndByte(query DataQuery) ([]byte, []byte) {
 	startTimestamp := make([]byte, TimeLen)
 	endTimestamp := make([]byte, TimeLen)
 
-	binary.BigEndian.PutUint64(startTimestamp, uint64(query.Start))
-	binary.BigEndian.PutUint64(endTimestamp, uint64(query.End))
+	binary.BigEndian.PutUint64(startTimestamp, query.Start)
+	binary.BigEndian.PutUint64(endTimestamp, query.End)
 
 	userKey := make([]byte, UserKeyLen)
 	qualifier := make([]byte, QualifierLen)


### PR DESCRIPTION
**Reference**
#61 

Reference issue에서 언급했듯이 불필요한 int64 -> uint64로의 형변환을 줄이기 위해 timestamp data의 type을 int6에서 uint64로 변경하였다.