### PR TITLE
Unify error handling of client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -183,7 +183,7 @@ func (client *Client) WriteFile(file string) (*ctypes.ResultBroadcastTx, error) 
 	return bres, err
 }
 
-func (client *Client) WriteFilesInDir(dir string, recursive bool) {
+func (client *Client) WriteFilesInDir(dir string, recursive bool) error {
 	if recursive == true {
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -205,9 +205,7 @@ func (client *Client) WriteFilesInDir(dir string, recursive bool) {
 			}
 			return nil
 		})
-		if err != nil {
-			fmt.Println(err)
-		}
+		return err
 	} else {
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -234,9 +232,7 @@ func (client *Client) WriteFilesInDir(dir string, recursive bool) {
 				return nil
 			}
 		})
-		if err != nil {
-			fmt.Println(err)
-		}
+		return err
 	}
 }
 
@@ -391,16 +387,16 @@ var writeCmd = &cobra.Command{
 			bres, err = client.WriteFile(filePath)
 		case directoryPath != "":
 			fmt.Printf("Read json data from files in directory: %s\n", directoryPath)
-			client.WriteFilesInDir(directoryPath, recursive)
+			err = client.WriteFilesInDir(directoryPath, recursive)
 		default:
 			fmt.Println("Read data from cli arguments")
 			bres, err = client.WriteData(uint64(time.Now().UnixNano()), ownerKey, qualifier, []byte(strings.Join(args, " ")))
 		}
+		if err != nil {
+			fmt.Printf("write err: %v\n", err)
+			os.Exit(1)
+		}
 		if directoryPath == "" {
-			if err != nil {
-				fmt.Printf("write err: %v\n", err)
-				os.Exit(1)
-			}
 			if bres.Code == code.CodeTypeOK {
 				fmt.Println("Write success.")
 			} else {

--- a/client/client_write_test.go
+++ b/client/client_write_test.go
@@ -140,7 +140,8 @@ func (suite *ClientTestSuite) TestClient_WriteFilesInDir() {
 	})
 	require.Nil(err, "directory traverse err: %+v", err)
 
-	suite.dbClient.WriteFilesInDir(TestDirectory, false)
+	err = suite.dbClient.WriteFilesInDir(TestDirectory, false)
+	require.Nil(err, "err: %+v", err)
 
 	require.Equal(initMempoolSize+len(fileBytes), mempool.Size())
 


### PR DESCRIPTION
**Reference**
#58 

**내용**
* 뒤죽박죽이던 client의 error handling을 하나의 방식으로 통합하였다.
  * WriteFilesInDir 함수를 제외한 client.go에 있는 함수들은 errors 패키지의 Wrap 함수를 이용해 error를 wrap하여 return 한다.
  * 실질적으로 client내의 함수를 호출하여 사용하는 cli command 부분에서 함수가 return하는 error를 출력하여 stdout으로 보여준다.
* 한줄로 작성할 수 있는 error의 경우 한줄로 간략화하였다.