### PR TITLE
Change switch case in metaDataQuery method from nil to emptySlice

### DIFF
--- a/master/MasterApplication_unit_test.go
+++ b/master/MasterApplication_unit_test.go
@@ -134,7 +134,7 @@ func (suite *MasterSuite) TestMasterApplication_time_only_Query() {
 	*/
 
 	//when
-	var emptySlice []byte
+	emptySlice := make([]byte,0)
 	metaQueryObj := types.MetaDataQueryObj{Start: 1545982882435375000, End: 1545982882435375002, OwnerKey: emptySlice, Qualifier: emptySlice}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)


### PR DESCRIPTION
Reference
#91 

MetaDataQuery시 nil을 기준으로 분기를 타서 empty slice의 경우 null의 response를 보내는 bug를 수정하였습니다.
emptySlice를 기준으로 분기를 타게 하였고 이에 해당하는 테스트 코드를 수정하였습니다