### PR TITLE
Add paust-db logger for MasterApplication

### DIFF
--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -174,7 +174,13 @@ var queryCmd = &cobra.Command{
 			fmt.Printf("Query err: %v\n", err)
 			os.Exit(1)
 		}
+		if res.Response.Code != code.CodeTypeOK {
+			fmt.Println("query fail.")
+			fmt.Println(res.Response.Log)
+			os.Exit(1)
+		}
 
+		fmt.Println("query success.")
 		fmt.Println(string(res.Response.Value))
 	},
 }
@@ -237,7 +243,13 @@ var fetchCmd = &cobra.Command{
 			fmt.Printf("Fetch err: %v\n", err)
 			os.Exit(1)
 		}
+		if res.Response.Code != code.CodeTypeOK {
+			fmt.Println("fetch fail.")
+			fmt.Println(res.Response.Log)
+			os.Exit(1)
+		}
 
+		fmt.Println("fetch success.")
 		fmt.Println(string(res.Response.Value))
 	},
 }

--- a/libs/log/fmt_logger.go
+++ b/libs/log/fmt_logger.go
@@ -1,0 +1,119 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/go-logfmt/logfmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+type pdbfmtEncoder struct {
+	*logfmt.Encoder
+	buf bytes.Buffer
+}
+
+func (l *pdbfmtEncoder) Reset() {
+	l.Encoder.Reset()
+	l.buf.Reset()
+}
+
+var pdbfmtEncoderPool = sync.Pool{
+	New: func() interface{} {
+		var enc pdbfmtEncoder
+		enc.Encoder = logfmt.NewEncoder(&enc.buf)
+		return &enc
+	},
+}
+
+type pdbfmtLogger struct {
+	w io.Writer
+}
+
+// NewPDBFmtLogger returns a logger that encodes keyvals to the Writer in
+// paust-db custom format. Note complex types (structs, maps, slices)
+// formatted as "%+v".
+//
+// Each log event produces no more than one call to w.Write.
+// The passed Writer must be safe for concurrent use by multiple goroutines if
+// the returned Logger will be used concurrently.
+func NewPDBFmtLogger(w io.Writer) log.Logger {
+	return &pdbfmtLogger{w}
+}
+
+func (l pdbfmtLogger) Log(keyvals ...interface{}) error {
+	enc := pdbfmtEncoderPool.Get().(*pdbfmtEncoder)
+	enc.Reset()
+	defer pdbfmtEncoderPool.Put(enc)
+
+	const unknown = "unknown"
+	lvl := "none"
+	msg := unknown
+
+	// indexes of keys to skip while encoding later
+	excludeIndexes := make([]int, 0)
+
+	for i := 0; i < len(keyvals)-1; i += 2 {
+		// Extract level
+		if keyvals[i] == level.Key() {
+			excludeIndexes = append(excludeIndexes, i)
+			switch keyvals[i+1].(type) {
+			case string:
+				lvl = keyvals[i+1].(string)
+			case level.Value:
+				lvl = keyvals[i+1].(level.Value).String()
+			default:
+				panic(fmt.Sprintf("level value of unknown type %T", keyvals[i+1]))
+			}
+			// and message
+		} else if keyvals[i] == msgKey {
+			excludeIndexes = append(excludeIndexes, i)
+			msg = keyvals[i+1].(string)
+			// and module (could be multiple keyvals; if such case last keyvalue wins)
+		}
+	}
+
+	// Form a custom paust-db line
+	//
+	// Example:
+	//     INFO [2016-05-02|11:06:44.322]   Put success
+	//
+	// Description:
+	//     INFO							- log level
+	//     [2016-05-02|11:06:44.322]    - our time format (see https://golang.org/src/time/format.go)
+	//     Put success					- message
+	enc.buf.WriteString(fmt.Sprintf("%-5s[%s] %-44s ", strings.ToUpper(lvl), time.Now().Format("2006-01-02|15:04:05.000"), msg))
+
+KeyvalueLoop:
+	for i := 0; i < len(keyvals)-1; i += 2 {
+		for _, j := range excludeIndexes {
+			if i == j {
+				continue KeyvalueLoop
+			}
+		}
+
+		err := enc.EncodeKeyval(keyvals[i], keyvals[i+1])
+		if err == logfmt.ErrUnsupportedValueType {
+			enc.EncodeKeyval(keyvals[i], fmt.Sprintf("%+v", keyvals[i+1]))
+		} else if err != nil {
+			return err
+		}
+	}
+
+	// Add newline to the end of the buffer
+	if err := enc.EndRecord(); err != nil {
+		return err
+	}
+
+	// The Logger interface requires implementations to be safe for concurrent
+	// use by multiple goroutines. For this implementation that means making
+	// only one call to l.w.Write() for each call to Log.
+	if _, err := l.w.Write(enc.buf.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/libs/log/logger.go
+++ b/libs/log/logger.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/kit/log/term"
+	"io"
+)
+
+type Logger interface {
+	Debug(msg string, keyvals ...interface{})
+	Info(msg string, keyvals ...interface{})
+	Error(msg string, keyvals ...interface{})
+
+	With(keyvals ...interface{}) Logger
+}
+
+const (
+	msgKey = "_msg" // "_" prefixed to avoid collisions
+)
+
+type pdbLogger struct {
+	srcLogger log.Logger
+}
+
+// Interface assertions
+var _ Logger = (*pdbLogger)(nil)
+
+// NewPDBLogger returns a logger that encodes msg and keyvals to the Writer
+// using go-kit's log as an underlying logger and our custom formatter. Note
+// that underlying logger could be swapped with something else.
+func NewPDBLogger(w io.Writer) Logger {
+	// Color by level value
+	colorFn := func(keyvals ...interface{}) term.FgBgColor {
+		if keyvals[0] != level.Key() {
+			panic(fmt.Sprintf("expected level key to be first, got %v", keyvals[0]))
+		}
+		switch keyvals[1].(level.Value).String() {
+		case "debug":
+			return term.FgBgColor{Fg: term.DarkGray}
+		case "error":
+			return term.FgBgColor{Fg: term.Red}
+		default:
+			return term.FgBgColor{}
+		}
+	}
+
+	return &pdbLogger{term.NewLogger(w, NewPDBFmtLogger, colorFn)}
+}
+
+// Info logs a message at level Info.
+func (l *pdbLogger) Info(msg string, keyvals ...interface{}) {
+	lWithLevel := level.Info(l.srcLogger)
+	if err := log.With(lWithLevel, msgKey, msg).Log(keyvals...); err != nil {
+		errLogger := level.Error(l.srcLogger)
+		log.With(errLogger, msgKey, msg).Log("err", err)
+	}
+}
+
+// Debug logs a message at level Debug.
+func (l *pdbLogger) Debug(msg string, keyvals ...interface{}) {
+	lWithLevel := level.Debug(l.srcLogger)
+	if err := log.With(lWithLevel, msgKey, msg).Log(keyvals...); err != nil {
+		errLogger := level.Error(l.srcLogger)
+		log.With(errLogger, msgKey, msg).Log("err", err)
+	}
+}
+
+// Error logs a message at level Error.
+func (l *pdbLogger) Error(msg string, keyvals ...interface{}) {
+	lWithLevel := level.Error(l.srcLogger)
+	lWithMsg := log.With(lWithLevel, msgKey, msg)
+	if err := lWithMsg.Log(keyvals...); err != nil {
+		lWithMsg.Log("err", err)
+	}
+}
+
+// With returns a new contextual logger with keyvals prepended to those passed
+// to calls to Info, Debug or Error.
+func (l *pdbLogger) With(keyvals ...interface{}) Logger {
+	return &pdbLogger{log.With(l.srcLogger, keyvals...)}
+}


### PR DESCRIPTION
**Reference**
#40 #58 

**내용**
* paust-db logger 추가
  * go-kit/log package를 활용하여 tm_logger를 만든 tendermint의 logger를 참고하여 paust-db logger 추가.
  * log level은 info, debug, error로 3개로 구분.
  * 아래와 같은 형식으로 로그가 출력됨.
```bash
INFO [2019-02-13|14:59:17.289] Put success                                  state=DeliverTx size=2
INFO [2019-02-13|14:59:17.289] Query success                                state=Query path=/query
INFO [2019-02-13|14:59:17.289] Fetch success                                state=Query path=/fetch
```
* MasterApplicatin.go의 error handling 변경 및 logging 추가
  * 기존의 fmt로 출력하던 error handling을 logger의 Error function을 통해 출력하도록 변경.
  * put, query, fetch 성공시 logging 추가.
  * master application error 발생 시 response의 log에 error 내용 포함해서 return하도록 변경.