### PR TITLE
Add paust-db logger filter and change logging of master application

### DIFF
--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"github.com/paust-team/paust-db/client"
+	"github.com/paust-team/paust-db/libs/log"
 	"github.com/paust-team/paust-db/master"
 	"github.com/stretchr/testify/suite"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -30,7 +31,7 @@ type ClientTestSuite struct {
 func (suite *ClientTestSuite) SetupSuite() {
 	testDir = "/tmp/" + cmn.RandStr(4)
 	os.MkdirAll(testDir, os.ModePerm)
-	app := master.NewMasterApplication(true, testDir)
+	app := master.NewMasterApplication(true, testDir, log.AllowDebug())
 	node = rpctest.StartTendermint(app)
 
 	rand.Seed(0)

--- a/cmd/paust-db/commands/master.go
+++ b/cmd/paust-db/commands/master.go
@@ -3,19 +3,26 @@ package commands
 import (
 	"fmt"
 	"github.com/paust-team/paust-db/consts"
+	"github.com/paust-team/paust-db/libs/log"
 	"github.com/paust-team/paust-db/master"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/abci/server"
 	"github.com/tendermint/tendermint/libs/common"
-	"github.com/tendermint/tendermint/libs/log"
+	tmlog "github.com/tendermint/tendermint/libs/log"
 	"os"
 )
 
-var dir string
+var dir, level string
 
 func Serve() error {
-	app := master.NewMasterApplication(true, dir)
-	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+	option, err := log.AllowLevel(level)
+	if err != nil {
+		fmt.Printf("level parsing err: %v\n", err)
+		os.Exit(1)
+	}
+
+	app := master.NewMasterApplication(true, dir, option)
+	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))
 
 	srv, err := server.NewServer(consts.ProtoAddr, consts.Transport, app)
 
@@ -49,4 +56,5 @@ var MasterCmd = &cobra.Command{
 
 func init() {
 	MasterCmd.Flags().StringVarP(&dir, "dir", "d", "/tmp", "directory for rocksdb")
+	MasterCmd.Flags().StringVarP(&level, "level", "l", "info", "set log level [debug|info|error|none]")
 }

--- a/libs/db/c_rocks_db.go
+++ b/libs/db/c_rocks_db.go
@@ -106,11 +106,11 @@ func (mBatch *cRocksDBBatch) SetColumnFamily(cf *gorocksdb.ColumnFamilyHandle, k
 }
 
 // Implements Batch.
-func (mBatch *cRocksDBBatch) Write() error {
+func (mBatch *cRocksDBBatch) Write() (int, error) {
 	if err := mBatch.db.db.Write(mBatch.db.wo, mBatch.batch); err != nil {
-		return err
+		return 0, err
 	}
-	return nil
+	return mBatch.batch.Count(), nil
 }
 
 //----------------------------------------

--- a/libs/db/c_rocks_db_batch_test.go
+++ b/libs/db/c_rocks_db_batch_test.go
@@ -12,7 +12,8 @@ func (suite *DBSuite) TestColumnFamilyBatchPutGet() {
 
 	batch := suite.DB.NewBatch()
 	batch.SetColumnFamily(suite.DB.ColumnFamilyHandles()[consts.DefaultCFNum], givenKey, givenValue)
-	err := batch.Write()
+	size, err := batch.Write()
+	require.Equal(1, size)
 	require.Nil(err, "Batch MetaColumnFamily Write Error : %v", err)
 
 	actualValue, err := suite.DB.GetDataFromColumnFamily(consts.DefaultCFNum, givenKey)

--- a/libs/db/types.go
+++ b/libs/db/types.go
@@ -36,7 +36,7 @@ type DB interface {
 
 type Batch interface {
 	SetColumnFamily(cf *gorocksdb.ColumnFamilyHandle, key, value []byte)
-	Write() error
+	Write() (int, error)
 }
 
 //----------------------------------------

--- a/libs/log/filter.go
+++ b/libs/log/filter.go
@@ -1,0 +1,110 @@
+package log
+
+import "fmt"
+
+type level byte
+
+const (
+	levelDebug level = 1 << iota
+	levelInfo
+	levelError
+)
+
+type filter struct {
+	next    Logger
+	allowed level // XOR'd levels
+}
+
+// NewFilter wraps next and implements filtering. See the commentary on the
+// Option functions for a detailed description of how to configure levels. If
+// no options are provided, all leveled log events created with Debug, Info or
+// Error helper methods are squelched.
+func NewFilter(next Logger, options ...Option) Logger {
+	l := &filter{
+		next: next,
+	}
+	for _, option := range options {
+		option(l)
+	}
+	return l
+}
+
+func (l *filter) Info(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelInfo != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Info(msg, keyvals...)
+}
+
+func (l *filter) Debug(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelDebug != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Debug(msg, keyvals...)
+}
+
+func (l *filter) Error(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelError != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Error(msg, keyvals...)
+}
+
+func (l *filter) With(keyvals ...interface{}) Logger {
+	return &filter{
+		next:    l.next.With(keyvals...),
+		allowed: l.allowed,
+	}
+}
+
+// Option sets a parameter for the filter.
+type Option func(*filter)
+
+// AllowLevel returns an option for the given level or error if no option exist
+// for such level.
+func AllowLevel(lvl string) (Option, error) {
+	switch lvl {
+	case "debug":
+		return AllowDebug(), nil
+	case "info":
+		return AllowInfo(), nil
+	case "error":
+		return AllowError(), nil
+	case "none":
+		return AllowNone(), nil
+	default:
+		return nil, fmt.Errorf("Expected either \"info\", \"debug\", \"error\" or \"none\" level, given %s", lvl)
+	}
+}
+
+// AllowAll is an alias for AllowDebug.
+func AllowAll() Option {
+	return AllowDebug()
+}
+
+// AllowDebug allows error, info and debug level log events to pass.
+func AllowDebug() Option {
+	return allowed(levelError | levelInfo | levelDebug)
+}
+
+// AllowInfo allows error and info level log events to pass.
+func AllowInfo() Option {
+	return allowed(levelError | levelInfo)
+}
+
+// AllowError allows only error level log events to pass.
+func AllowError() Option {
+	return allowed(levelError)
+}
+
+// AllowNone allows no leveled log events to pass.
+func AllowNone() Option {
+	return allowed(0)
+}
+
+func allowed(allowed level) Option {
+	return func(l *filter) { l.allowed = allowed }
+}

--- a/libs/log/filter_test.go
+++ b/libs/log/filter_test.go
@@ -1,0 +1,87 @@
+package log_test
+
+import (
+	"bytes"
+	"github.com/paust-team/paust-db/libs/log"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestVariousLevels(t *testing.T) {
+	testCases := []struct {
+		name    string
+		allowed log.Option
+		want    string
+	}{
+		{
+			"AllowAll",
+			log.AllowAll(),
+			strings.Join([]string{
+				`DEBUG\[.+\] here \s+ log_level="debug log"\n`,
+				`INFO \[.+\] here \s+ log_level="info log"\n`,
+				`ERROR\[.+\] here \s+ log_level="error log"\n$`,
+			}, ""),
+		},
+		{
+			"AllowDebug",
+			log.AllowDebug(),
+			strings.Join([]string{
+				`DEBUG\[.+\] here \s+ log_level="debug log"\n`,
+				`INFO \[.+\] here \s+ log_level="info log"\n`,
+				`ERROR\[.+\] here \s+ log_level="error log"\n$`,
+			}, ""),
+		},
+		{
+			"AllowInfo",
+			log.AllowInfo(),
+			strings.Join([]string{
+				`INFO \[.+\] here \s+ log_level="info log"\n`,
+				`ERROR\[.+\] here \s+ log_level="error log"\n$`,
+			}, ""),
+		},
+		{
+			"AllowError",
+			log.AllowError(),
+			strings.Join([]string{
+				`ERROR\[.+\] here \s+ log_level="error log"\n$`,
+			}, ""),
+		},
+		{
+			"AllowNone",
+			log.AllowNone(),
+			``,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.NewFilter(log.NewPDBLogger(&buf), tc.allowed)
+
+			logger.Debug("here", "log_level", "debug log")
+			logger.Info("here", "log_level", "info log")
+			logger.Error("here", "log_level", "error log")
+
+			want, have := tc.want, buf.String()
+			assert.Regexp(t, regexp.MustCompile(want), have)
+		})
+	}
+}
+
+func TestLevelContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := log.NewPDBLogger(&buf)
+	logger = log.NewFilter(logger, log.AllowError())
+	logger = logger.With("context", "value")
+
+	logger.Error("foo", "bar", "baz")
+	want, have := `ERROR\[.+\] foo \s+ context=value bar=baz\n$`, buf.String()
+	assert.Regexp(t, regexp.MustCompile(want), have)
+
+	buf.Reset()
+	logger.Info("foo", "bar", "baz")
+	assert.EqualValues(t, ``, buf.String())
+}

--- a/libs/log/fmt_logger.go
+++ b/libs/log/fmt_logger.go
@@ -3,8 +3,8 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	kitlog "github.com/go-kit/kit/log"
+	kitlevel "github.com/go-kit/kit/log/level"
 	"github.com/go-logfmt/logfmt"
 	"io"
 	"strings"
@@ -41,7 +41,7 @@ type pdbfmtLogger struct {
 // Each log event produces no more than one call to w.Write.
 // The passed Writer must be safe for concurrent use by multiple goroutines if
 // the returned Logger will be used concurrently.
-func NewPDBFmtLogger(w io.Writer) log.Logger {
+func NewPDBFmtLogger(w io.Writer) kitlog.Logger {
 	return &pdbfmtLogger{w}
 }
 
@@ -59,13 +59,13 @@ func (l pdbfmtLogger) Log(keyvals ...interface{}) error {
 
 	for i := 0; i < len(keyvals)-1; i += 2 {
 		// Extract level
-		if keyvals[i] == level.Key() {
+		if keyvals[i] == kitlevel.Key() {
 			excludeIndexes = append(excludeIndexes, i)
 			switch keyvals[i+1].(type) {
 			case string:
 				lvl = keyvals[i+1].(string)
-			case level.Value:
-				lvl = keyvals[i+1].(level.Value).String()
+			case kitlevel.Value:
+				lvl = keyvals[i+1].(kitlevel.Value).String()
 			default:
 				panic(fmt.Sprintf("level value of unknown type %T", keyvals[i+1]))
 			}

--- a/libs/log/fmt_logger.go
+++ b/libs/log/fmt_logger.go
@@ -73,7 +73,6 @@ func (l pdbfmtLogger) Log(keyvals ...interface{}) error {
 		} else if keyvals[i] == msgKey {
 			excludeIndexes = append(excludeIndexes, i)
 			msg = keyvals[i+1].(string)
-			// and module (could be multiple keyvals; if such case last keyvalue wins)
 		}
 	}
 

--- a/libs/log/fmt_logger_test.go
+++ b/libs/log/fmt_logger_test.go
@@ -1,0 +1,109 @@
+package log_test
+
+import (
+	"bytes"
+	"errors"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/paust-team/paust-db/libs/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"math"
+	"regexp"
+	"testing"
+)
+
+func TestPDBFmtLogger(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	logger := log.NewPDBFmtLogger(buf)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	err := logger.Log("hello", "world")
+	require.Nil(err, "Log error: %+v", err)
+	assert.Regexp(regexp.MustCompile(`NONE \[.+\] unknown \s+ hello=world\n$`), buf.String())
+
+	buf.Reset()
+	err = logger.Log("a", 1, "err", errors.New("error"))
+	require.Nil(err, "Log error: %+v", err)
+	assert.Regexp(regexp.MustCompile(`NONE \[.+\] unknown \s+ a=1 err=error\n$`), buf.String())
+
+	buf.Reset()
+	err = logger.Log("std_map", map[int]int{1: 2}, "my_map", mymap{0: 0})
+	require.Nil(err, "Log error: %+v", err)
+	assert.Regexp(regexp.MustCompile(`NONE \[.+\] unknown \s+ std_map=map\[1:2\] my_map=special_behavior\n$`), buf.String())
+
+	buf.Reset()
+	err = logger.Log("level", "error")
+	require.Nil(err, "Log error: %+v", err)
+	assert.Regexp(regexp.MustCompile(`ERROR\[.+\] unknown \s+\n$`), buf.String())
+
+	buf.Reset()
+	err = logger.Log("_msg", "Hello")
+	require.Nil(err, "Log error: %+v", err)
+	assert.Regexp(regexp.MustCompile(`NONE \[.+\] Hello \s+\n$`), buf.String())
+
+	buf.Reset()
+}
+
+func BenchmarkPDBFmtLoggerSimple(b *testing.B) {
+	benchmarkRunnerKitlog(b, log.NewPDBFmtLogger(ioutil.Discard), baseMessage)
+}
+
+func BenchmarkPDBFmtLoggerContextual(b *testing.B) {
+	benchmarkRunnerKitlog(b, log.NewPDBFmtLogger(ioutil.Discard), withMessage)
+}
+
+func TestPDBFmtLoggerConcurrency(t *testing.T) {
+	t.Parallel()
+	testConcurrency(t, log.NewPDBFmtLogger(ioutil.Discard), 10000)
+}
+
+func benchmarkRunnerKitlog(b *testing.B, logger kitlog.Logger, f func(kitlog.Logger)) {
+	lc := kitlog.With(logger, "common_key", "common_value")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f(lc)
+	}
+}
+
+var (
+	baseMessage = func(logger kitlog.Logger) { logger.Log("foo_key", "foo_value") }
+	withMessage = func(logger kitlog.Logger) { kitlog.With(logger, "a", "b").Log("d", "f") }
+)
+
+// These test are designed to be run with the race detector.
+
+func testConcurrency(t *testing.T, logger kitlog.Logger, total int) {
+	n := int(math.Sqrt(float64(total)))
+	share := total / n
+
+	errC := make(chan error, n)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			errC <- spam(logger, share)
+		}()
+	}
+
+	for i := 0; i < n; i++ {
+		err := <-errC
+		require.Nil(t, err, "concurrent loggin error: %v", err)
+	}
+}
+
+func spam(logger kitlog.Logger, count int) error {
+	for i := 0; i < count; i++ {
+		err := logger.Log("key", i)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type mymap map[int]int
+
+func (m mymap) String() string { return "special_behavior" }

--- a/libs/log/logger_test.go
+++ b/libs/log/logger_test.go
@@ -1,0 +1,42 @@
+package log_test
+
+import (
+	"bytes"
+	"github.com/go-logfmt/logfmt"
+	"github.com/paust-team/paust-db/libs/log"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestLoggerLogsItsErrors(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := log.NewPDBLogger(&buf)
+	logger.Info("foo", "", "bar")
+	msg := strings.TrimSpace(buf.String())
+	assert.Contains(t, msg, logfmt.ErrInvalidKey.Error())
+}
+
+func BenchmarkPDBLoggerSimple(b *testing.B) {
+	benchmarkRunner(b, log.NewPDBLogger(ioutil.Discard), baseInfoMessage)
+}
+
+func BenchmarkPDBLoggerContextual(b *testing.B) {
+	benchmarkRunner(b, log.NewPDBLogger(ioutil.Discard), withInfoMessage)
+}
+
+func benchmarkRunner(b *testing.B, logger log.Logger, f func(log.Logger)) {
+	lc := logger.With("common_key", "common_value")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f(lc)
+	}
+}
+
+var (
+	baseInfoMessage = func(logger log.Logger) { logger.Info("foo_message", "foo_key", "foo_value") }
+	withInfoMessage = func(logger log.Logger) { logger.With("a", "b").Info("c", "d", "f") }
+)

--- a/master/MasterApplication.go
+++ b/master/MasterApplication.go
@@ -28,7 +28,7 @@ type MasterApplication struct {
 	logger log.Logger
 }
 
-func NewMasterApplication(serial bool, dir string) *MasterApplication {
+func NewMasterApplication(serial bool, dir string, option log.Option) *MasterApplication {
 	hash := make([]byte, 8)
 	database, err := db.NewCRocksDB(consts.DBName, dir)
 
@@ -41,7 +41,7 @@ func NewMasterApplication(serial bool, dir string) *MasterApplication {
 		serial: serial,
 		hash:   hash,
 		db:     database,
-		logger: log.NewPDBLogger(os.Stdout),
+		logger: log.NewFilter(log.NewPDBLogger(log.NewSyncWriter(os.Stdout)), option),
 	}
 }
 

--- a/master/MasterApplication_test.go
+++ b/master/MasterApplication_test.go
@@ -3,6 +3,7 @@ package master_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/paust-team/paust-db/libs/log"
 	"github.com/paust-team/paust-db/master"
 	"github.com/paust-team/paust-db/types"
 	"github.com/stretchr/testify/suite"
@@ -76,7 +77,7 @@ func (suite *MasterSuite) SetupTest() {
 
 	os.RemoveAll(testDir)
 	os.Mkdir(testDir, perm)
-	suite.app = master.NewMasterApplication(true, testDir)
+	suite.app = master.NewMasterApplication(true, testDir, log.AllowDebug())
 	require.NotNil(suite.app, "app should not be nil")
 }
 


### PR DESCRIPTION
**Reference**
#99 #40 

**내용**
* #99 에서 작업한 logger 내용 중에 피드백을 받고 변경한 부분을 추가
  * put, query, fetch의 info logging에 전달받은 tx, query obj 데이터를 출력하도록 수정.
  * 실제로 batch write가 일어나 데이터가 저장된 경우 flush logging을 남기도록 추가.
  * debug, info, error, none으로 로그 레벨을 조절할 수 있는 filter 추가.
    * master application을 CLI에서 실행할 때 flag를 통해 변경할 수 있으며 default는 info level이다.
* paust-db log package에 대한 test code 추가.
  * logger_test.go
  * fmt_logger_test.go
  * filter_test.go