### PR TITLE
Change default directory of paust-db master application

### DIFF
--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -31,7 +31,8 @@ type ClientTestSuite struct {
 func (suite *ClientTestSuite) SetupSuite() {
 	testDir = "/tmp/" + cmn.RandStr(4)
 	os.MkdirAll(testDir, os.ModePerm)
-	app := master.NewMasterApplication(true, testDir, log.AllowDebug())
+	app, err := master.NewMasterApplication(true, testDir, log.AllowDebug())
+	suite.Require().Nil(err, "err: %+v", err)
 	node = rpctest.StartTendermint(app)
 
 	rand.Seed(0)

--- a/master/MasterApplication_test.go
+++ b/master/MasterApplication_test.go
@@ -75,10 +75,13 @@ func (suite *MasterSuite) SetupSuite() {
 func (suite *MasterSuite) SetupTest() {
 	require := suite.Require()
 
+	var err error
+
 	os.RemoveAll(testDir)
 	os.Mkdir(testDir, perm)
-	suite.app = master.NewMasterApplication(true, testDir, log.AllowDebug())
+	suite.app, err = master.NewMasterApplication(true, testDir, log.AllowDebug())
 	require.NotNil(suite.app, "app should not be nil")
+	require.Nil(err, "err: %+v", err)
 }
 
 func (suite *MasterSuite) TearDownTest() {


### PR DESCRIPTION
**Reference**
#108 

**내용**
* paust-db CLI 바이너리를 통해 master 명령어 실행 시 MasterApplication을 위한 default directory를 기존의 "/tmp"에서 "$HOME/.paust-db"로 변경하였습니다.
* NewMasterApplication 함수의 에러 처리방식을 변경하였습니다.
  * 기존에는 함수 내에서 fmt.Println을 통해 출력하는 것이 전부였지만 error를 함수 return 값에 포함해서 error 발생 시 paust-db abci server가 실행되지 않도록 변경하였습니다.