### PR TITLE
Change broadcast method of put function and add elapsed time printing of client CLI

### DIFF
--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paust-team/paust-db/client/util"
 	"github.com/paust-team/paust-db/consts"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/tendermint/abci/example/code"
 	"golang.org/x/crypto/ed25519"
 	"os"
 	"strconv"
@@ -114,11 +113,15 @@ var putCmd = &cobra.Command{
 					fmt.Printf("%s: Put err: %v\n", path, err)
 					continue
 				}
-				if res.Code == code.CodeTypeOK {
-					fmt.Printf("%s: put success.\n", path)
-				} else {
+				switch {
+				case res.CheckTx.IsErr():
 					fmt.Printf("%s: put fail.\n", path)
-					fmt.Println(res.Log)
+					fmt.Println(res.CheckTx.Log)
+				case res.DeliverTx.IsErr():
+					fmt.Printf("%s: put fail.\n", path)
+					fmt.Println(res.DeliverTx.Log)
+				default:
+					fmt.Printf("%s: put success.\n", path)
 				}
 			}
 		} else {
@@ -127,11 +130,15 @@ var putCmd = &cobra.Command{
 				fmt.Printf("Put err: %v\n", err)
 				os.Exit(1)
 			}
-			if res.Code == code.CodeTypeOK {
-				fmt.Println("put success.")
-			} else {
+			switch {
+			case res.CheckTx.IsErr():
 				fmt.Println("put fail.")
-				fmt.Println(res.Log)
+				fmt.Println(res.CheckTx.Log)
+			case res.DeliverTx.IsErr():
+				fmt.Println("put fail.")
+				fmt.Println(res.DeliverTx.Log)
+			default:
+				fmt.Println("put success.")
 			}
 		}
 	},
@@ -174,7 +181,7 @@ var queryCmd = &cobra.Command{
 			fmt.Printf("Query err: %v\n", err)
 			os.Exit(1)
 		}
-		if res.Response.Code != code.CodeTypeOK {
+		if res.Response.IsErr() {
 			fmt.Println("query fail.")
 			fmt.Println(res.Response.Log)
 			os.Exit(1)
@@ -243,7 +250,7 @@ var fetchCmd = &cobra.Command{
 			fmt.Printf("Fetch err: %v\n", err)
 			os.Exit(1)
 		}
-		if res.Response.Code != code.CodeTypeOK {
+		if res.Response.IsErr() {
 			fmt.Println("fetch fail.")
 			fmt.Println(res.Response.Log)
 			os.Exit(1)

--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -108,7 +108,9 @@ var putCmd = &cobra.Command{
 		HTTPClient := client.NewHTTPClient(consts.Remote)
 		if inputDataObjMap != nil {
 			for path, inputDataObj := range inputDataObjMap {
+				startTime := time.Now()
 				res, err := HTTPClient.Put(inputDataObj)
+				endTime := time.Now()
 				if err != nil {
 					fmt.Printf("%s: Put err: %v\n", path, err)
 					continue
@@ -121,11 +123,13 @@ var putCmd = &cobra.Command{
 					fmt.Printf("%s: put fail.\n", path)
 					fmt.Println(res.DeliverTx.Log)
 				default:
-					fmt.Printf("%s: put success.\n", path)
+					fmt.Printf("%s: put success. elapsed time: %v\n", path, endTime.Sub(startTime).Round(time.Millisecond).String())
 				}
 			}
 		} else {
+			startTime := time.Now()
 			res, err := HTTPClient.Put(inputDataObjs)
+			endTime := time.Now()
 			if err != nil {
 				fmt.Printf("Put err: %v\n", err)
 				os.Exit(1)
@@ -138,7 +142,7 @@ var putCmd = &cobra.Command{
 				fmt.Println("put fail.")
 				fmt.Println(res.DeliverTx.Log)
 			default:
-				fmt.Println("put success.")
+				fmt.Printf("put success. elapsed time: %v\n", endTime.Sub(startTime).Round(time.Millisecond).String())
 			}
 		}
 	},
@@ -176,7 +180,9 @@ var queryCmd = &cobra.Command{
 		}
 
 		HTTPClient := client.NewHTTPClient(consts.Remote)
+		startTime := time.Now()
 		res, err := HTTPClient.Query(start, end, ownerKey, qualifier)
+		endTime := time.Now()
 		if err != nil {
 			fmt.Printf("Query err: %v\n", err)
 			os.Exit(1)
@@ -187,7 +193,7 @@ var queryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("query success.")
+		fmt.Printf("query success. elapsed time: %v\n", endTime.Sub(startTime).Round(time.Millisecond).String())
 		fmt.Println(string(res.Response.Value))
 	},
 }
@@ -245,7 +251,9 @@ var fetchCmd = &cobra.Command{
 		}
 
 		HTTPClient := client.NewHTTPClient(consts.Remote)
+		startTime := time.Now()
 		res, err := HTTPClient.Fetch(*inputFetchObj)
+		endTime := time.Now()
 		if err != nil {
 			fmt.Printf("Fetch err: %v\n", err)
 			os.Exit(1)
@@ -256,7 +264,7 @@ var fetchCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("fetch success.")
+		fmt.Printf("fetch success. elapsed time: %v\n", endTime.Sub(startTime).Round(time.Millisecond).String())
 		fmt.Println(string(res.Response.Value))
 	},
 }

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -27,7 +27,7 @@ func NewHTTPClient(remote string) *HTTPClient {
 	}
 }
 
-func (client *HTTPClient) Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTx, error) {
+func (client *HTTPClient) Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTxCommit, error) {
 	var baseDataObjs []types.BaseDataObj
 	for _, dataObj := range dataObjs {
 		if len(dataObj.OwnerKey) != consts.OwnerKeyLen {
@@ -45,7 +45,7 @@ func (client *HTTPClient) Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastT
 		return nil, errors.Wrap(err, "marshal failed")
 	}
 
-	bres, err := client.rpcClient.BroadcastTxSync(jsonBytes)
+	bres, err := client.rpcClient.BroadcastTxCommit(jsonBytes)
 	return bres, err
 }
 

--- a/client/httpclient_write_test.go
+++ b/client/httpclient_write_test.go
@@ -2,13 +2,9 @@ package client_test
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"github.com/paust-team/paust-db/client"
-	"github.com/paust-team/paust-db/types"
 	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
-	tendermint "github.com/tendermint/tendermint/types"
 	"time"
 )
 
@@ -16,27 +12,17 @@ func (suite *ClientTestSuite) TestClient_Put() {
 	require := require.New(suite.T())
 
 	mempool := node.MempoolReactor().Mempool
-	initMempoolSize := mempool.Size()
 
 	timestamp := uint64(time.Now().UnixNano())
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestamp, Salt: suite.salt[0]})
-	require.Nil(err, "json marshal err: %+v", err)
-	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
-	require.Nil(err, "json marshal err: %+v", err)
-
 	dataObjs := []client.InputDataObj{{Timestamp: timestamp, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier), Data: data}}
 	bres, err := suite.dbClient.Put(dataObjs)
 
 	require.Nil(err, "err: %+v", err)
-	require.Equal(abci.CodeTypeOK, bres.Code)
+	require.True(bres.CheckTx.IsOK())
+	require.True(bres.DeliverTx.IsOK())
 
-	require.Equal(initMempoolSize+1, mempool.Size())
-
-	txs := mempool.ReapMaxTxs(-1)
-	require.EqualValues(tendermint.Tx(tx), txs[0])
-
-	mempool.Flush()
+	require.Equal(0, mempool.Size())
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -7,8 +7,8 @@ import (
 
 // Client는 paust-db와 communicate하는 기본적인 client임
 type Client interface {
-	// Put는 InputDataObj slice의 데이터를 write하고 그 결과를 tendermint의 ResultBroadcastTx로 return.
-	Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTx, error)
+	// Put는 InputDataObj slice의 데이터를 write하고 그 결과를 tendermint의 ResultBroadcastTxCommit로 return.
+	Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTxCommit, error)
 
 	// Query는 start와 end사이에 있는 데이터의 metadata를 ResultABCIQuery에 담아서 return.
 	// ownerKey와 qualifier가 명시된 경우 해당 ownerKey, qualifier와 일치하는 데이터만을 read.


### PR DESCRIPTION
**Reference**
#112 

**내용**
* Change put implementation of httpclient
  * 실제로 데이터가 put이 완료되는 것은 commit이 된 시점이므로 put 함수 내에서 tx을 broadcast하는 함수를 BroadcastTxSync에서 BroadcastTxCommit로 변경.
  * put function의 return type이 ResultBroadcastTxCommit로 바뀌므로 error handling 로직 변경.
* Add elapsed time print for CLI put command