### PR TITLE
Fix query time range bug

### DIFF
--- a/client/httpclient_internal_test.go
+++ b/client/httpclient_internal_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/types"
 	"github.com/stretchr/testify/require"
@@ -17,9 +18,15 @@ func TestHTTPClient_deSerializeKeyObj(t *testing.T) {
 	require := require.New(t)
 	var timestamp1 uint64 = 1547772882435375000
 	var timestamp2 uint64 = 1547772960049177000
-	rowKey1, err := json.Marshal(types.KeyObj{Timestamp: timestamp1, Salt: 0})
+	timestampBytes1 := make([]byte, 8)
+	timestampBytes2 := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestampBytes1, timestamp1)
+	binary.BigEndian.PutUint64(timestampBytes2, timestamp2)
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0)
+	rowKey1, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes1, Salt: salt})
 	require.Nil(err, "json marshal err: %+v", err)
-	rowKey2, err := json.Marshal(types.KeyObj{Timestamp: timestamp2, Salt: 0})
+	rowKey2, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes2, Salt: salt})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	// MetaDataResObj deserialize

--- a/client/httpclient_read_test.go
+++ b/client/httpclient_read_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/client"
 	"github.com/paust-team/paust-db/types"
@@ -16,10 +17,14 @@ func (suite *ClientTestSuite) TestClient_Query() {
 
 	mempool := node.MempoolReactor().Mempool
 	timestamp := uint64(time.Now().UnixNano())
+	timestampBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestampBytes, timestamp)
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestamp, Salt: 0})
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0)
+	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes, Salt: salt})
 	require.Nil(err, "json marshal err: %+v", err)
 	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
 	require.Nil(err, "json marshal err: %+v", err)
@@ -47,10 +52,14 @@ func (suite *ClientTestSuite) TestClient_Fetch() {
 
 	mempool := node.MempoolReactor().Mempool
 	timestamp := uint64(time.Now().UnixNano())
+	timestampBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestampBytes, timestamp)
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestamp, Salt: 0})
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0)
+	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes, Salt: salt})
 	require.Nil(err, "json marshal err: %+v", err)
 	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
 	require.Nil(err, "json marshal err: %+v", err)

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -8,7 +8,6 @@ import (
 	cmn "github.com/tendermint/tendermint/libs/common"
 	nm "github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/rpc/test"
-	"math/rand"
 	"os"
 	"testing"
 )
@@ -25,7 +24,6 @@ type ClientTestSuite struct {
 	suite.Suite
 
 	dbClient client.Client
-	salt     []uint8
 }
 
 func (suite *ClientTestSuite) SetupSuite() {
@@ -34,9 +32,6 @@ func (suite *ClientTestSuite) SetupSuite() {
 	app, err := master.NewMasterApplication(true, testDir, log.AllowDebug())
 	suite.Require().Nil(err, "err: %+v", err)
 	node = rpctest.StartTendermint(app)
-
-	rand.Seed(0)
-	suite.salt = append(suite.salt, uint8(rand.Intn(256)), uint8(rand.Intn(256)), uint8(rand.Intn(256)), uint8(rand.Intn(256)))
 }
 
 func (suite *ClientTestSuite) TearDownSuite() {
@@ -47,7 +42,6 @@ func (suite *ClientTestSuite) TearDownSuite() {
 
 func (suite *ClientTestSuite) SetupTest() {
 	suite.dbClient = client.NewHTTPClient(rpctest.GetConfig().RPC.ListenAddress)
-	rand.Seed(0)
 }
 
 func (suite *ClientTestSuite) TearDownTest() {

--- a/master/MasterApplication_test.go
+++ b/master/MasterApplication_test.go
@@ -2,6 +2,7 @@ package master_test
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/libs/log"
 	"github.com/paust-team/paust-db/master"
@@ -45,8 +46,14 @@ func (suite *MasterSuite) SetupSuite() {
 	var err error
 
 	//test data 설정
-	givenKeyObj1 = types.KeyObj{Timestamp: 1545982882435375000, Salt: 0}
-	givenKeyObj2 = types.KeyObj{Timestamp: 1545982882435375001, Salt: 0}
+	timestamp1 := make([]byte, 8)
+	timestamp2 := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestamp1, 1545982882435375000)
+	binary.BigEndian.PutUint64(timestamp2, 1545982882435375001)
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0)
+	givenKeyObj1 = types.KeyObj{Timestamp: timestamp1, Salt: salt}
+	givenKeyObj2 = types.KeyObj{Timestamp: timestamp2, Salt: salt}
 
 	givenRowKey1, err = json.Marshal(givenKeyObj1)
 	require.Nil(err)

--- a/master/MasterApplication_unit_test.go
+++ b/master/MasterApplication_unit_test.go
@@ -1,6 +1,7 @@
 package master_test
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/consts"
 	"github.com/paust-team/paust-db/types"
@@ -136,7 +137,11 @@ func (suite *MasterSuite) TestMasterApplication_time_only_Query() {
 
 	//when
 	emptySlice := make([]byte, 0)
-	metaQueryObj := types.QueryObj{Start: 1545982882435375000, End: 1545982882435375002, OwnerKey: emptySlice, Qualifier: emptySlice}
+	start := make([]byte, 8)
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(start, 1545982882435375000)
+	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerKey: emptySlice, Qualifier: emptySlice}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
 	metaQuery := abciTypes.RequestQuery{Data: metaQueryByteArr, Path: consts.QueryPath}
@@ -196,7 +201,11 @@ func (suite *MasterSuite) TestMasterApplication_qualifier_Query() {
 
 	//when
 	emptySlice := make([]byte, 0)
-	metaQueryObj := types.QueryObj{Start: 1545982882435375000, End: 1545982882435375002, OwnerKey: emptySlice, Qualifier: []byte("Memory")}
+	start := make([]byte, 8)
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(start, 1545982882435375000)
+	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerKey: emptySlice, Qualifier: []byte("Memory")}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
 	metaQuery := abciTypes.RequestQuery{Data: metaQueryByteArr, Path: consts.QueryPath}
@@ -258,7 +267,11 @@ func (suite *MasterSuite) TestMasterApplication_ownerKey_Query() {
 
 	//when
 	emptySlice := make([]byte, 0)
-	metaQueryObj := types.QueryObj{Start: 1545982882435375000, End: 1545982882435375002, OwnerKey: givenOwnerKey2, Qualifier: emptySlice}
+	start := make([]byte, 8)
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(start, 1545982882435375000)
+	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerKey: givenOwnerKey2, Qualifier: emptySlice}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
 	metaQuery := abciTypes.RequestQuery{Data: metaQueryByteArr, Path: consts.QueryPath}
@@ -318,7 +331,11 @@ func (suite *MasterSuite) TestMasterApplication_both_Query() {
 	*/
 
 	//when
-	metaQueryObj := types.QueryObj{Start: 1545982882435375000, End: 1545982882435375002, OwnerKey: givenOwnerKey, Qualifier: []byte("Memory")}
+	start := make([]byte, 8)
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(start, 1545982882435375000)
+	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerKey: givenOwnerKey, Qualifier: []byte("Memory")}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
 	metaQuery := abciTypes.RequestQuery{Data: metaQueryByteArr, Path: consts.QueryPath}

--- a/types/types.go
+++ b/types/types.go
@@ -1,14 +1,15 @@
 package types
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 )
 
 //TODO offset 추가
 type KeyObj struct {
-	Timestamp uint64 `json:"timestamp"`
-	Salt      uint8  `json:"salt"`
+	Timestamp []byte `json:"timestamp"`
+	Salt      []byte `json:"salt"`
 }
 
 type MetaDataObj struct {
@@ -28,8 +29,8 @@ type BaseDataObj struct {
 }
 
 type QueryObj struct {
-	Start     uint64 `json:"start"`
-	End       uint64 `json:"end"`
+	Start     []byte `json:"start"`
+	End       []byte `json:"end"`
 	OwnerKey  []byte `json:"ownerKey"`
 	Qualifier []byte `json:"qualifier"`
 }
@@ -40,8 +41,10 @@ type FetchObj struct {
 
 // 주어진 DataQuery로부터 시작할 지점(startByte)과 마지막 지점(endByte)을 구한다.
 func CreateStartByteAndEndByte(query QueryObj) ([]byte, []byte) {
-	startKeyObj := KeyObj{Timestamp: query.Start}
-	endKeyObj := KeyObj{Timestamp: query.End}
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0x0000)
+	startKeyObj := KeyObj{Timestamp: query.Start, Salt: salt}
+	endKeyObj := KeyObj{Timestamp: query.End, Salt: salt}
 
 	startByte, err := json.Marshal(startKeyObj)
 	if err != nil {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/types"
 	"github.com/stretchr/testify/assert"
@@ -9,14 +10,20 @@ import (
 
 func TestCreateStartByteAndEndByte(t *testing.T) {
 	//given
-	givenQuery := types.QueryObj{Start: 0, End: 1545982882435375000}
+	start := make([]byte, 8)
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(start, 0)
+	binary.BigEndian.PutUint64(end, 1545982882435375000)
+	givenQuery := types.QueryObj{Start: start, End: end}
 
 	//when
 	actualStartByte, actualEndByte := types.CreateStartByteAndEndByte(givenQuery)
 
 	//then
-	expectStartKeyObj := types.KeyObj{Timestamp: givenQuery.Start}
-	expectEndKeyObj := types.KeyObj{Timestamp: givenQuery.End}
+	salt := make([]byte, 2)
+	binary.BigEndian.PutUint16(salt, 0x0000)
+	expectStartKeyObj := types.KeyObj{Timestamp: givenQuery.Start, Salt: salt}
+	expectEndKeyObj := types.KeyObj{Timestamp: givenQuery.End, Salt: salt}
 
 	expectStartByte, err := json.Marshal(expectStartKeyObj)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Reference**
#117 

**내용**
* types.go의 KeyObj.Timestamp, QueryObj.Start, QueryObj.End를 기존의 uint64 타입의 nano second timestamp에서 byte slice로 변경.
  * uint64의 timestamp를 big endian encoding을 통해 byte slice로 변환하는 과정을 추가.
* CreateStartByteAndEndByte function의 keyObj에 salt 추가.