### PR TITLE
Change qualifier of client to string

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -108,9 +108,9 @@ cli 상에서 `client.InputDataObj`형식을 가진 JSON object의 array를 사�
 ```
 # put data of STDIN
 $ echo '[
-        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1","data":"YWJj"},
-        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt","data":"ZGVm"},
-        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"c3BlZWQ=","data":"Z2hp"}
+        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}","data":"YWJj"},
+        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}","data":"ZGVm"},
+        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"{\"type\":\"price\"}","data":"Z2hp"}
 ]' | paust-db-client put -s
 Read json data from STDIN
 put success.
@@ -139,7 +139,7 @@ Read json data from files in directory: /root/writeDirectory
 - Cli argument 방식
 ```
 # put data of cli arguments
-$ paust-db-client put 123456 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q c3BlZWQ=
+$ paust-db-client put 123456 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"temperature"}'
 Read data from cli arguments
 put success.
 ```
@@ -152,14 +152,14 @@ Usage:
   paust-db-client put [data to put] [flags]
 
 Flags:
-  -d, --directory string        Directory path
-  -e, --endpoint string         Endpoint of paust-db (default "localhost:26657")
-  -f, --file string             File path
-  -h, --help                    help for put
-  -o, --ownerKey bytesBase64    Base64 encoded ED25519 public key
-  -q, --qualifier bytesBase64   Base64 encoded data qualifier
-  -r, --recursive               Write all files and folders recursively
-  -s, --stdin                   Input json data from standard input
+  -d, --directory string       Directory path
+  -e, --endpoint string        Endpoint of paust-db (default "localhost:26657")
+  -f, --file string            File path
+  -h, --help                   help for put
+  -o, --ownerKey bytesBase64   Base64 encoded ED25519 public key
+  -q, --qualifier string       Data qualifier(JSON object)
+  -r, --recursive              Write all files and folders recursively
+  -s, --stdin                  Input json data from standard input
 ```
 
 ### Query data
@@ -170,28 +170,28 @@ flag를 통해 ownerKey, qualifier를 명시하면 특정 ownerKey, qualifier와
 # Query with start, end
 $ paust-db-client query 1544772882435375000 1544772882435375001
 query success.
-[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI4ODI0MzUzNzUwMDAsInNhbHQiOjQ1fQ==","timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1"}]
+[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI4ODI0MzUzNzUwMDAsInNhbHQiOjQ1fQ==","timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}"}]
 ```
 - start, end timestamp와 ownerKey 명시
 ```
 # Query with start, end, ownerKey
 $ paust-db-client query 1544772882435375000 1544772967331458001 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=
 query success.
-[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjAwNDkxNzcwMDAsInNhbHQiOjIxNX0=","timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt"}]
+[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjAwNDkxNzcwMDAsInNhbHQiOjIxNX0=","timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}"}]
 ```
 - start, end timestamp와 qualifier 명시
 ```
 # Query with start, end, qualifier
-$ paust-db-client query 1544772882435375000 1544772967331458001 -q c3BlZWQ=
+$ paust-db-client query 1544772882435375000 1544772967331458001 -q '{"type":"price"}'
 query success.
-[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjczMzE0NTgwMDAsInNhbHQiOjM5fQ==","timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"c3BlZWQ="}]
+[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjczMzE0NTgwMDAsInNhbHQiOjM5fQ==","timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"{\"type\":\"price\"}"}]
 ```
 - start, end timestamp와 ownerKey, qualifier 명시
 ```
 # Query with start, end, ownerKey, qualifier
-$ paust-db-client query 1544772882435375000 1544772967331458001 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q bWVt
+$ paust-db-client query 1544772882435375000 1544772967331458001 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"speed"}'
 query success.
-[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjAwNDkxNzcwMDAsInNhbHQiOjIxNX0=","timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt"}]
+[{"id":"eyJ0aW1lc3RhbXAiOjE1NDQ3NzI5NjAwNDkxNzcwMDAsInNhbHQiOjIxNX0=","timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}"}]
 ```
 
 기타 query에 관련된 usage를 --help를 통해 확인할 수 있음
@@ -204,10 +204,10 @@ Usage:
   paust-db-client query start end [flags]
 
 Flags:
-  -e, --endpoint string         Endpoint of paust-db (default "localhost:26657")
-  -h, --help                    help for query
-  -o, --ownerKey bytesBase64    Base64 encoded ED25519 public key
-  -q, --qualifier bytesBase64   Base64 encoded data qualifier
+  -e, --endpoint string        Endpoint of paust-db (default "localhost:26657")
+  -h, --help                   help for query
+  -o, --ownerKey bytesBase64   Base64 encoded ED25519 public key
+  -q, --qualifier string       Data qualifier(JSON object)
 ```
 
 ### Fetch Data

--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -60,7 +60,7 @@ var putCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		qualifier, err := cmd.Flags().GetBytesBase64("qualifier")
+		qualifier, err := cmd.Flags().GetString("qualifier")
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -179,7 +179,7 @@ var queryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		qualifier, err := cmd.Flags().GetBytesBase64("qualifier")
+		qualifier, err := cmd.Flags().GetString("qualifier")
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -298,7 +298,7 @@ var statusCmd = &cobra.Command{
 		}
 
 		HTTPClient := client.NewHTTPClient(endpoint)
-		_, err = HTTPClient.Query(1, 2, []byte{}, []byte{})
+		_, err = HTTPClient.Query(1, 2, []byte{}, "")
 		if err != nil {
 			fmt.Println("not running")
 		} else {
@@ -324,7 +324,7 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	putCmd.Flags().BytesBase64P("ownerKey", "o", nil, "Base64 encoded ED25519 public key")
-	putCmd.Flags().BytesBase64P("qualifier", "q", nil, "Base64 encoded data qualifier")
+	putCmd.Flags().StringP("qualifier", "q", "", "Data qualifier(JSON object)")
 	putCmd.Flags().StringP("file", "f", "", "File path")
 	putCmd.Flags().StringP("directory", "d", "", "Directory path")
 	putCmd.Flags().BoolP("stdin", "s", false, "Input json data from standard input")
@@ -334,7 +334,7 @@ func init() {
 	fetchCmd.Flags().StringP("file", "f", "", "File path")
 	fetchCmd.Flags().StringP("endpoint", "e", "localhost:26657", "Endpoint of paust-db")
 	queryCmd.Flags().BytesBase64P("ownerKey", "o", nil, "Base64 encoded ED25519 public key")
-	queryCmd.Flags().BytesBase64P("qualifier", "q", nil, "Base64 encoded data qualifier")
+	queryCmd.Flags().StringP("qualifier", "q", "", "Data qualifier(JSON object)")
 	queryCmd.Flags().StringP("endpoint", "e", "localhost:26657", "Endpoint of paust-db")
 	statusCmd.Flags().StringP("endpoint", "e", "localhost:26657", "Endpoint of paust-db")
 	ClientCmd.AddCommand(putCmd)

--- a/client/httpclient_internal_test.go
+++ b/client/httpclient_internal_test.go
@@ -34,7 +34,7 @@ func TestHTTPClient_deSerializeKeyObj(t *testing.T) {
 	require.Nil(err, "base64 decode err: %+v", err)
 	metaDataObjs, err := json.Marshal([]types.MetaDataObj{{RowKey: rowKey1, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, {RowKey: rowKey2, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}})
 	require.Nil(err, "json marshal err: %+v", err)
-	outputQueryObjs, err := json.Marshal([]OutputQueryObj{{Id: rowKey1, Timestamp: timestamp1, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, {Id: rowKey2, Timestamp: timestamp2, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}})
+	outputQueryObjs, err := json.Marshal([]OutputQueryObj{{Id: rowKey1, Timestamp: timestamp1, OwnerKey: pubKeyBytes, Qualifier: TestQualifier}, {Id: rowKey2, Timestamp: timestamp2, OwnerKey: pubKeyBytes, Qualifier: TestQualifier}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	deserializedBytes, err := deSerializeKeyObj(metaDataObjs, true)

--- a/client/httpclient_read_test.go
+++ b/client/httpclient_read_test.go
@@ -28,7 +28,7 @@ func (suite *ClientTestSuite) TestClient_Query() {
 	require.Nil(err, "json marshal err: %+v", err)
 	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
 	require.Nil(err, "json marshal err: %+v", err)
-	expectedValue, err := json.Marshal([]client.OutputQueryObj{{Id: rowKey, Timestamp: timestamp, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier)}})
+	expectedValue, err := json.Marshal([]client.OutputQueryObj{{Id: rowKey, Timestamp: timestamp, OwnerKey: pubKeyBytes, Qualifier: TestQualifier}})
 	require.Nil(err, "json marshal err: %+v", err)
 
 	c := rpcClient.NewLocal(node)
@@ -40,7 +40,7 @@ func (suite *ClientTestSuite) TestClient_Query() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.Query(timestamp, timestamp+1, pubKeyBytes, []byte(TestQualifier))
+	res, err := suite.dbClient.Query(timestamp, timestamp+1, pubKeyBytes, TestQualifier)
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(expectedValue, qres.Value)

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -17,7 +17,7 @@ var testDir string
 
 const (
 	TestPubKey    = "Pe8PPI4Mq7kJIjDJjffoTl6s5EezGQSyIcu5Y2KYDaE="
-	TestQualifier = "testQualifier"
+	TestQualifier = "{\"type\":\"testQualifier\"}"
 )
 
 type ClientTestSuite struct {

--- a/client/httpclient_write_test.go
+++ b/client/httpclient_write_test.go
@@ -17,7 +17,7 @@ func (suite *ClientTestSuite) TestClient_Put() {
 	data := []byte(cmn.RandStr(8))
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(TestPubKey)
 	require.Nil(err, "base64 decode err: %+v", err)
-	dataObjs := []client.InputDataObj{{Timestamp: timestamp, OwnerKey: pubKeyBytes, Qualifier: []byte(TestQualifier), Data: data}}
+	dataObjs := []client.InputDataObj{{Timestamp: timestamp, OwnerKey: pubKeyBytes, Qualifier: TestQualifier, Data: data}}
 	bres, err := suite.dbClient.Put(dataObjs)
 
 	require.Nil(err, "err: %+v", err)

--- a/client/interface.go
+++ b/client/interface.go
@@ -13,7 +13,7 @@ type Client interface {
 	// Query는 start와 end사이에 있는 데이터의 metadata를 ResultABCIQuery에 담아서 return.
 	// ownerKey와 qualifier가 명시된 경우 해당 ownerKey, qualifier와 일치하는 데이터만을 read.
 	// ResultABCIQuery.Response.Value에 실제 read한 데이터가 OutputQueryObj의 slice로 담겨있음.
-	Query(start uint64, end uint64, ownerKey []byte, qualifier []byte) (*ctypes.ResultABCIQuery, error)
+	Query(start uint64, end uint64, ownerKey []byte, qualifier string) (*ctypes.ResultABCIQuery, error)
 
 	// Fetch는 InputFetchObj와 일치하는 데이터를 tendermint의 ResultABCIQuery에 담아서 return.
 	// ResultABCIQuery.Response.Value에 실제 read한 데이터가 OutputFetchObj의 slice로 담겨있음.

--- a/client/types.go
+++ b/client/types.go
@@ -3,10 +3,11 @@ package client
 // InputDataObj는 Put function의 write model.
 // Timestamp는 unix timestamp이며 단위는 nano second임.
 // OwnerKey는 ed25519 public key이며 32byte.
+// Qualifier는 json object이며 string.
 type InputDataObj struct {
 	Timestamp uint64 `json:"timestamp"`
 	OwnerKey  []byte `json:"ownerKey"`
-	Qualifier []byte `json:"qualifier"`
+	Qualifier string `json:"qualifier"`
 	Data      []byte `json:"data"`
 }
 
@@ -20,11 +21,12 @@ type InputFetchObj struct {
 // Id는 data의 고유한 id.
 // Timestamp는 unix timestamp이며 단위는 nano second임.
 // OwnerKey는 ed25519 public key이며 32byte.
+// Qualifier는 json object이며 string.
 type OutputQueryObj struct {
 	Id        []byte `json:"id"`
 	Timestamp uint64 `json:"timestamp"`
 	OwnerKey  []byte `json:"ownerKey"`
-	Qualifier []byte `json:"qualifier"`
+	Qualifier string `json:"qualifier"`
 }
 
 // OutputFetchObj는 Fetch function의 result data type.

--- a/client/util/util_test.go
+++ b/client/util/util_test.go
@@ -21,9 +21,9 @@ func TestGetInputDataFromStdin(t *testing.T) {
 	require := require.New(t)
 
 	inputData := `[
-        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1","data":"YWJj"},
-        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt","data":"ZGVm"},
-        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"c3BlZWQ=","data":"Z2hp"}
+        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}","data":"YWJj"},
+        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}","data":"ZGVm"},
+        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"{\"type\":\"price\"}","data":"Z2hp"}
 ]`
 	var dataObjs []client.InputDataObj
 	err := json.Unmarshal([]byte(inputData), &dataObjs)

--- a/test/write_directory/recursive_directory/test.json
+++ b/test/write_directory/recursive_directory/test.json
@@ -1,3 +1,3 @@
 [
-        {"timestamp":1547024561435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1","data":"YWJj"}
+        {"timestamp":1547024561435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}","data":"YWJj"}
 ]

--- a/test/write_directory/test1.json
+++ b/test/write_directory/test1.json
@@ -1,3 +1,3 @@
 [
-        {"timestamp":1546937137435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1","data":"YWJj"}
+        {"timestamp":1546937137435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}","data":"YWJj"}
 ]

--- a/test/write_directory/test2.json
+++ b/test/write_directory/test2.json
@@ -1,3 +1,3 @@
 [
-        {"timestamp":1546937137049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt","data":"ZGVm"}
+        {"timestamp":1546937137049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}","data":"ZGVm"}
 ]

--- a/test/write_directory/test3.json
+++ b/test/write_directory/test3.json
@@ -1,3 +1,3 @@
 [
-        {"timestamp":1546937137331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"c3BlZWQ=","data":"Z2hp"}
+        {"timestamp":1546937137331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"{\"type\":\"price\"}","data":"Z2hp"}
 ]

--- a/test/write_file.json
+++ b/test/write_file.json
@@ -1,5 +1,5 @@
 [
-        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"Y3B1","data":"YWJj"},
-        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"bWVt","data":"ZGVm"},
-        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"c3BlZWQ=","data":"Z2hp"}
+        {"timestamp":1544772882435375000,"ownerKey":"NwdTf+S9+H5lsB6Us+s5Y1ChdB1aKECA6gsyGCa8SCM=","qualifier":"{\"type\":\"temperature\"}","data":"YWJj"},
+        {"timestamp":1544772960049177000,"ownerKey":"mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY=","qualifier":"{\"type\":\"speed\"}","data":"ZGVm"},
+        {"timestamp":1544772967331458000,"ownerKey":"aFw+o2z13LFCXzk7HptFoOY54s7VGDeQQVo32REPFCU=","qualifier":"{\"type\":\"price\"}","data":"Z2hp"}
 ]


### PR DESCRIPTION
**Reference**
#122 

**내용**
* server와 client가 데이터를 주고받을 때의 qualifier는 byte slice로 주고받는 것이 좋지만 실질적으로 data를 put, query하는 client는 encoding된 byte slice보다 json object 형식의 string이 더 직관적이고 알아보기 쉬으므로 client 내의 qualifier를 string으로 변경하기로 결정.
  * client/types.go내 InputDataObj, OutputQueryObj struct의 Qualifier field를 기존의 byte slice에서 string으로 모두 변경.
  * Client interface의 Query 함수에서 qualifier argument를 byte slice에서
string으로 변경.
  * 이에 따른 Client interface를 구현한 HTTPClient 수정 및
paust-db-client 구현 수정.