### PR TITLE
Change query interface of client

### DIFF
--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -193,7 +193,7 @@ var queryCmd = &cobra.Command{
 
 		HTTPClient := client.NewHTTPClient(endpoint)
 		startTime := time.Now()
-		res, err := HTTPClient.Query(start, end, ownerKey, qualifier)
+		res, err := HTTPClient.Query(client.InputQueryObj{Start: start, End: end, OwnerKey: ownerKey, Qualifier: qualifier})
 		endTime := time.Now()
 		if err != nil {
 			fmt.Printf("Query err: %v\n", err)
@@ -298,7 +298,7 @@ var statusCmd = &cobra.Command{
 		}
 
 		HTTPClient := client.NewHTTPClient(endpoint)
-		_, err = HTTPClient.Query(1, 2, []byte{}, "")
+		_, err = HTTPClient.Query(client.InputQueryObj{Start: 1, End: 2, OwnerKey: []byte{}, Qualifier: ""})
 		if err != nil {
 			fmt.Println("not running")
 		} else {

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -54,20 +54,20 @@ func (client *HTTPClient) Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastT
 	return bres, err
 }
 
-func (client *HTTPClient) Query(start uint64, end uint64, ownerKey []byte, qualifier string) (*ctypes.ResultABCIQuery, error) {
-	if ownerKey == nil {
+func (client *HTTPClient) Query(queryObj InputQueryObj) (*ctypes.ResultABCIQuery, error) {
+	if queryObj.OwnerKey == nil {
 		return nil, errors.Errorf("ownerKey must not be nil.")
 	}
 
-	if len(ownerKey) != 0 && len(ownerKey) != consts.OwnerKeyLen {
-		return nil, errors.Errorf("wrong ownerKey length. Expected %v, got %v", consts.OwnerKeyLen, len(ownerKey))
+	if len(queryObj.OwnerKey) != 0 && len(queryObj.OwnerKey) != consts.OwnerKeyLen {
+		return nil, errors.Errorf("wrong ownerKey length. Expected %v, got %v", consts.OwnerKeyLen, len(queryObj.OwnerKey))
 	}
 
 	startTimestamp := make([]byte, 8)
 	endTimestamp := make([]byte, 8)
-	binary.BigEndian.PutUint64(startTimestamp, start)
-	binary.BigEndian.PutUint64(endTimestamp, end)
-	jsonBytes, err := json.Marshal(types.QueryObj{Start: startTimestamp, End: endTimestamp, OwnerKey: ownerKey, Qualifier: []byte(qualifier)})
+	binary.BigEndian.PutUint64(startTimestamp, queryObj.Start)
+	binary.BigEndian.PutUint64(endTimestamp, queryObj.End)
+	jsonBytes, err := json.Marshal(types.QueryObj{Start: startTimestamp, End: endTimestamp, OwnerKey: queryObj.OwnerKey, Qualifier: []byte(queryObj.Qualifier)})
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal failed")
 	}

--- a/client/httpclient_read_test.go
+++ b/client/httpclient_read_test.go
@@ -40,7 +40,7 @@ func (suite *ClientTestSuite) TestClient_Query() {
 
 	require.Equal(0, mempool.Size())
 
-	res, err := suite.dbClient.Query(timestamp, timestamp+1, pubKeyBytes, TestQualifier)
+	res, err := suite.dbClient.Query(client.InputQueryObj{Start: timestamp, End: timestamp + 1, OwnerKey: pubKeyBytes, Qualifier: TestQualifier})
 	qres := res.Response
 	if suite.Nil(err) && suite.True(qres.IsOK()) {
 		suite.EqualValues(expectedValue, qres.Value)

--- a/client/interface.go
+++ b/client/interface.go
@@ -10,10 +10,10 @@ type Client interface {
 	// Put는 InputDataObj slice의 데이터를 write하고 그 결과를 tendermint의 ResultBroadcastTxCommit로 return.
 	Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTxCommit, error)
 
-	// Query는 start와 end사이에 있는 데이터의 metadata를 ResultABCIQuery에 담아서 return.
-	// ownerKey와 qualifier가 명시된 경우 해당 ownerKey, qualifier와 일치하는 데이터만을 read.
+	// Query는 InputQueryObj의 Start와 End사이에 있는 데이터의 metadata를 ResultABCIQuery에 담아서 return.
+	// InputQueryObj에 OwnerKey와 Qualifier가 명시된 경우 해당 OwnerKey, Qualifier와 일치하는 데이터만을 read.
 	// ResultABCIQuery.Response.Value에 실제 read한 데이터가 OutputQueryObj의 slice로 담겨있음.
-	Query(start uint64, end uint64, ownerKey []byte, qualifier string) (*ctypes.ResultABCIQuery, error)
+	Query(queryObj InputQueryObj) (*ctypes.ResultABCIQuery, error)
 
 	// Fetch는 InputFetchObj와 일치하는 데이터를 tendermint의 ResultABCIQuery에 담아서 return.
 	// ResultABCIQuery.Response.Value에 실제 read한 데이터가 OutputFetchObj의 slice로 담겨있음.

--- a/client/types.go
+++ b/client/types.go
@@ -11,6 +11,17 @@ type InputDataObj struct {
 	Data      []byte `json:"data"`
 }
 
+// InputQueryObj는 Query function의 read model.
+// Start, End는 unix timestamp이며 단위는 nano second임.
+// OwnerKey는 ed25519 public key이며 32byte.
+// Qualifier는 json object이며 string.
+type InputQueryObj struct {
+	Start     uint64 `json:"start"`
+	End       uint64 `json:"end"`
+	OwnerKey  []byte `json:"ownerKey"`
+	Qualifier string `json:"qualifier"`
+}
+
 // InputFetchObj는 Fetch function의 read model.
 // Id는 data의 고유한 id.
 type InputFetchObj struct {


### PR DESCRIPTION
**Reference**
#125 

**내용**
* Client interface의 Put, Query, Fetch 함수 parameter의 일관성과 추후의 다중 Query plan을 위해서 Query 함수의 parameter를 여러개의 다른 field가 아닌 하나의 struct type으로 변경하기로 결정.
  * Client interface에서 Query의 argument를 기존의 start, end, ownerKey, qualifier에서 이 모두를 포함하는 하나의 struct인 InputQueryObj로 변경.