### PR TITLE
Add a script file for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: xenial
+language: go
+
+go:
+  - 1.11.x
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y git cmake g++ libsnappy-dev
+  - git clone -b v5.17.2 https://github.com/facebook/rocksdb.git && cd rocksdb && cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF && make -j `nproc` && sudo make install && cd - && rm -rf rocksdb
+  - go get -t ./master ./client ./libs/db ./libs/log
+
+script:
+  - go test ./master ./client ./libs/db ./libs/log


### PR DESCRIPTION
.travis.yml을 추가하였습니다.

우리의 spec에 맞도록 golang 1.11.x 를 기준으로 하였는데, 추후에 golang master 버전에 대해서도 테스트하여 compatibility를 유지해야 할 것 같습니다.

또한, go test를 각 패키지별로 하도록 되어있는데 이는 모든 패키지를 scan할 수 있는 자동화 스크립트가 추후에 필요할 것으로 보입니다.

이 PR이 머지가 된 후에 README.md에 travis-ci badge를 달고 모든 PR은 travis-ci를 자동으로 수행하도록 하겠습니다.