### PR TITLE
Add error handling of putting zero-value timestamp data and change data input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ $ go get github.com/paust-team/paust-db/client/cmd/paust-db-client
 
 Name|Description
 ---|---
-timestamp | Unix timestamp(nanosec)
-ownerKey | Base64 encoded ED2519 public key
-qulifier | Schemeless json string
+timestamp | Essential. Unix timestamp(nanosec)
+ownerKey | Essential. Base64 encoded ED25519 public key(32byte)
+qualifier | Schemeless json string
 data | Base64 encoded data 
 
 

--- a/client/README.md
+++ b/client/README.md
@@ -177,17 +177,18 @@ Read json data from files in directory: /root/writeDirectory
 timestamp를 명시하지 않으면 현재 시간으로 timestamp가 설정됨.
 ```
 # put data of cli arguments
-$ paust-db-client put 123456 -t 1552391844405076000 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"temperature"}'
+$ paust-db-client put 6BM= -t 1552391844405076000 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"temperature"}'
 Read data from cli arguments
 put success.
 ```
 기타 put 에 관련된 usage 를 --help 를 통해 확인할 수 있음 
 ```
 $ paust-db-client put --help
-Put data to DB
+Put data to DB.
+'data' is base64 encoded byte array.
 
 Usage:
-  paust-db-client put [data to put] [flags]
+  paust-db-client put data [flags]
 
 Flags:
   -d, --directory string       Directory path

--- a/client/README.md
+++ b/client/README.md
@@ -29,7 +29,7 @@ import "github.com/paust-team/paust-db/client"
 Name|Type|Description
 ---|---|---
 Timestamp | uint64 | Unix timestamp(nanosec)
-OwnerKey | []byte | ED2519 public key
+OwnerKey | []byte | ED2519 public key(32byte)
 Qualifier | string | schemeless json string
 Data | []byte | Data to be stored
 
@@ -57,8 +57,8 @@ Name|Type|Description
 ---|---|---
 Start | uint64 | Unix timestamp(nanosec)
 End | uint64 | Unix timestamp(nanosec)
-OwnerKey | []byte | ED2519 public key
-Qualifier | string | schemeless json string
+OwnerKey | []byte | ED2519 public key(32byte) or empty byte slice
+Qualifier | string | schemeless json string or empty string
 
 ```go
 // Example
@@ -131,6 +131,15 @@ Use "paust-db-client [command] --help" for more information about a command.
 ### Put data
 paust-db-client put command 를 이용하여 여러 방법으로 데이터를 time series db에 쓸 수 있음
 put data 구조는 `client.InputDataObj` 를 따름
+#### JSON object Data 
+
+Name|Description
+---|---
+timestamp | Essential. Unix timestamp(nanosec)
+ownerKey | Essential. Base64 encoded ED25519 public key(32byte)
+qualifier | Schemeless json string
+data | Base64 encoded data 
+
 - Stdin 방식
 cli 상에서 `client.InputDataObj`형식을 가진 JSON object의 array를 사용하여 put 할 수 있음
 ```
@@ -165,9 +174,10 @@ Read json data from files in directory: /root/writeDirectory
 ```
 
 - Cli argument 방식
+timestamp를 명시하지 않으면 현재 시간으로 timestamp가 설정됨.
 ```
 # put data of cli arguments
-$ paust-db-client put 123456 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"temperature"}'
+$ paust-db-client put 123456 -t 1552391844405076000 -o mnhKcUWnR1iYTm6o4SJ/X0FV67QFIytpLB03EmWM1CY= -q '{"type":"temperature"}'
 Read data from cli arguments
 put success.
 ```
@@ -188,11 +198,13 @@ Flags:
   -q, --qualifier string       Data qualifier(JSON object)
   -r, --recursive              Write all files and folders recursively
   -s, --stdin                  Input json data from standard input
+  -t, --timestamp uint         Unix timestamp(in nanoseconds) (default 1552391845405076000)
 ```
 
 ### Query data
 paust-db-client query command 를 이용하여 start, end timestamp 사이에 있는 time series 데이터의 metadata를 가져올 수 있음
 flag를 통해 ownerKey, qualifier를 명시하면 특정 ownerKey, qualifier와 일치하는 데이터만 가져 옴
+query object 구조는 `client.InputQueryObj` 를 따름
 - start, end timestamp명시
 ```
 # Query with start, end
@@ -241,6 +253,12 @@ Flags:
 ### Fetch Data
 paust-db-client fetch command 를 이용하여 여러 방법으로 time series db의 데이터를 읽을 수 있음
 fetch object 구조는 `client.InputFetchObj` 를 따름
+#### JSON object Data 
+
+Name|Description
+---|---
+ids | Array of Base64 encoded id.
+
 - STDIN 방식
 cli 상에서 `client.InputFetchObj`형식을 가진 JSON object의 array를 사용하여 특정 id를 가진 데이터를 fetch 할 수 있음
 ```

--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -54,6 +54,12 @@ var putCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		timestamp, err := cmd.Flags().GetUint64("timestamp")
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
 		ownerKey, err := cmd.Flags().GetBytesBase64("ownerKey")
 		if err != nil {
 			fmt.Println(err)
@@ -104,11 +110,15 @@ var putCmd = &cobra.Command{
 			}
 		default:
 			fmt.Println("Read data from cli arguments")
+			if timestamp == 0 {
+				fmt.Printf("timestamp must not be 0.")
+				os.Exit(1)
+			}
 			if len(ownerKey) != consts.OwnerKeyLen {
 				fmt.Printf("wrong ownerKey length. Expected %v, got %v\n", consts.OwnerKeyLen, len(ownerKey))
 				os.Exit(1)
 			}
-			inputDataObjs = append(inputDataObjs, client.InputDataObj{Timestamp: uint64(time.Now().UnixNano()), OwnerKey: ownerKey, Qualifier: qualifier, Data: []byte(strings.Join(args, " "))})
+			inputDataObjs = append(inputDataObjs, client.InputDataObj{Timestamp: timestamp, OwnerKey: ownerKey, Qualifier: qualifier, Data: []byte(strings.Join(args, " "))})
 		}
 
 		HTTPClient := client.NewHTTPClient(endpoint)
@@ -323,6 +333,7 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
+	putCmd.Flags().Uint64P("timestamp", "t", uint64(time.Now().UnixNano()), "Unix timestamp(in nanoseconds)")
 	putCmd.Flags().BytesBase64P("ownerKey", "o", nil, "Base64 encoded ED25519 public key")
 	putCmd.Flags().StringP("qualifier", "q", "", "Data qualifier(JSON object)")
 	putCmd.Flags().StringP("file", "f", "", "File path")

--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/crypto/ed25519"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -27,8 +26,11 @@ var ClientCmd = &cobra.Command{
 }
 
 var putCmd = &cobra.Command{
-	Use:   "put [data to put]",
-	Short: "Put data to DB",
+	Use:   "put data",
+	Args:  cobra.ExactArgs(1),
+	Short: "Put data to DB.",
+	Long: `Put data to DB.
+'data' is base64 encoded byte array.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		stdin, err := cmd.Flags().GetBool("stdin")
 		if err != nil {
@@ -78,8 +80,9 @@ var putCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if stdin == false && filePath == "" && directoryPath == "" && len(args) == 0 {
-			fmt.Println("you should specify data to put")
+		data, err := base64.StdEncoding.DecodeString(args[0])
+		if err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
 
@@ -118,7 +121,7 @@ var putCmd = &cobra.Command{
 				fmt.Printf("wrong ownerKey length. Expected %v, got %v\n", consts.OwnerKeyLen, len(ownerKey))
 				os.Exit(1)
 			}
-			inputDataObjs = append(inputDataObjs, client.InputDataObj{Timestamp: timestamp, OwnerKey: ownerKey, Qualifier: qualifier, Data: []byte(strings.Join(args, " "))})
+			inputDataObjs = append(inputDataObjs, client.InputDataObj{Timestamp: timestamp, OwnerKey: ownerKey, Qualifier: qualifier, Data: data})
 		}
 
 		HTTPClient := client.NewHTTPClient(endpoint)

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -31,6 +31,9 @@ func NewHTTPClient(remote string) *HTTPClient {
 func (client *HTTPClient) Put(dataObjs []InputDataObj) (*ctypes.ResultBroadcastTxCommit, error) {
 	var baseDataObjs []types.BaseDataObj
 	for _, dataObj := range dataObjs {
+		if dataObj.Timestamp == 0 {
+			return nil, errors.Errorf("timestamp must not be 0.")
+		}
 		if len(dataObj.OwnerKey) != consts.OwnerKeyLen {
 			return nil, errors.Errorf("%s: wrong ownerKey length. Expected %v, got %v", base64.StdEncoding.EncodeToString(dataObj.OwnerKey), consts.OwnerKeyLen, len(dataObj.OwnerKey))
 		}

--- a/client/types.go
+++ b/client/types.go
@@ -13,8 +13,8 @@ type InputDataObj struct {
 
 // InputQueryObj는 Query function의 read model.
 // Start, End는 unix timestamp이며 단위는 nano second임.
-// OwnerKey는 ed25519 public key이며 32byte.
-// Qualifier는 json object이며 string.
+// OwnerKey는 ed25519 public key이며 32byte. OwnerKey를 제한하고 싶지 않다면 empty byte slice를 넣음.
+// Qualifier는 json object이며 string. Qualifier를 제한하고 싶지 않다면 empty string을 넣음.
 type InputQueryObj struct {
 	Start     uint64 `json:"start"`
 	End       uint64 `json:"end"`


### PR DESCRIPTION
**Reference**
#132 

**내용**
* Add client error handling for zero-value timestamp
  * Client interface의 Put function 내에서 InputDataObj의 timestamp가 0인 경우 에러를 발생하도록 수정.
* client cli에서 argument를 통해 단일 데이터 put할 때에도 flag로 timestamp 명시 가능하도록 변경.
  * timestamp flag를 따로 명시하지않은 경우 현재 시간으로 timestamp가 설정됨.
* Change data input type of put command of CLI
  * client CLI에서 argument로 단일 데이터 put을 할 때 file, stdin에서 데이터를 받을 때와 동일하게 data는 base64 encoding 된 것을 받도록 변경.