### PR TITLE
Fix client cli put command bug

### DIFF
--- a/client/cmd/paust-db-client/commands/client.go
+++ b/client/cmd/paust-db-client/commands/client.go
@@ -26,8 +26,7 @@ var ClientCmd = &cobra.Command{
 }
 
 var putCmd = &cobra.Command{
-	Use:   "put data",
-	Args:  cobra.ExactArgs(1),
+	Use:   "put [data]",
 	Short: "Put data to DB.",
 	Long: `Put data to DB.
 'data' is base64 encoded byte array.`,
@@ -80,9 +79,8 @@ var putCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		data, err := base64.StdEncoding.DecodeString(args[0])
-		if err != nil {
-			fmt.Println(err)
+		if stdin == false && filePath == "" && directoryPath == "" && len(args) == 0 {
+			fmt.Println("you should specify data to put")
 			os.Exit(1)
 		}
 
@@ -119,6 +117,11 @@ var putCmd = &cobra.Command{
 			}
 			if len(ownerKey) != consts.OwnerKeyLen {
 				fmt.Printf("wrong ownerKey length. Expected %v, got %v\n", consts.OwnerKeyLen, len(ownerKey))
+				os.Exit(1)
+			}
+			data, err := base64.StdEncoding.DecodeString(args[0])
+			if err != nil {
+				fmt.Println(err)
 				os.Exit(1)
 			}
 			inputDataObjs = append(inputDataObjs, client.InputDataObj{Timestamp: timestamp, OwnerKey: ownerKey, Qualifier: qualifier, Data: data})


### PR DESCRIPTION
put command를 exact argument를 1로 설정한 #133 PR때문에 발생한 버그를 고쳤습니다.
위의 PR의 경우 client cli에서 put command를 입력할 시 무조건 argument를 1개 넘겨주어야 했습니다.
put command의 exact argument 조건을 삭제해 원래대로 롤백하여 버그를 해결하였습니다.