### PR TITLE
Change rowkey structure

### DIFF
--- a/client/httpclient_internal_test.go
+++ b/client/httpclient_internal_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/types"
 	"github.com/stretchr/testify/require"
@@ -17,16 +16,8 @@ func TestHTTPClient_deSerializeKeyObj(t *testing.T) {
 	require := require.New(t)
 	var timestamp1 uint64 = 1547772882435375000
 	var timestamp2 uint64 = 1547772960049177000
-	timestampBytes1 := make([]byte, 8)
-	timestampBytes2 := make([]byte, 8)
-	binary.BigEndian.PutUint64(timestampBytes1, timestamp1)
-	binary.BigEndian.PutUint64(timestampBytes2, timestamp2)
-	salt := make([]byte, 2)
-	binary.BigEndian.PutUint16(salt, 0)
-	rowKey1, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes1, Salt: salt})
-	require.Nil(err, "json marshal err: %+v", err)
-	rowKey2, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes2, Salt: salt})
-	require.Nil(err, "json marshal err: %+v", err)
+	rowKey1 := types.GetRowKey(timestamp1, 0)
+	rowKey2 := types.GetRowKey(timestamp2, 0)
 
 	// MetaDataResObj deserialize
 	metaDataObjs, err := json.Marshal([]types.MetaDataObj{{RowKey: rowKey1, OwnerId: TestOwnerId, Qualifier: []byte(TestQualifier)}, {RowKey: rowKey2, OwnerId: TestOwnerId, Qualifier: []byte(TestQualifier)}})

--- a/client/httpclient_read_test.go
+++ b/client/httpclient_read_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/client"
 	"github.com/paust-team/paust-db/types"
@@ -16,14 +15,9 @@ func (suite *ClientTestSuite) TestClient_Query() {
 
 	mempool := node.MempoolReactor().Mempool
 	timestamp := uint64(time.Now().UnixNano())
-	timestampBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(timestampBytes, timestamp)
 	data := []byte(cmn.RandStr(8))
 
-	salt := make([]byte, 2)
-	binary.BigEndian.PutUint16(salt, 0)
-	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes, Salt: salt})
-	require.Nil(err, "json marshal err: %+v", err)
+	rowKey := types.GetRowKey(timestamp, 0)
 	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerId: TestOwnerId, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
 	require.Nil(err, "json marshal err: %+v", err)
 	expectedValue, err := json.Marshal([]client.OutputQueryObj{{Id: rowKey, Timestamp: timestamp, OwnerId: TestOwnerId, Qualifier: TestQualifier}})
@@ -50,13 +44,8 @@ func (suite *ClientTestSuite) TestClient_Fetch() {
 
 	mempool := node.MempoolReactor().Mempool
 	timestamp := uint64(time.Now().UnixNano())
-	timestampBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(timestampBytes, timestamp)
 	data := []byte(cmn.RandStr(8))
-	salt := make([]byte, 2)
-	binary.BigEndian.PutUint16(salt, 0)
-	rowKey, err := json.Marshal(types.KeyObj{Timestamp: timestampBytes, Salt: salt})
-	require.Nil(err, "json marshal err: %+v", err)
+	rowKey := types.GetRowKey(timestamp, 0)
 	tx, err := json.Marshal([]types.BaseDataObj{{MetaData: types.MetaDataObj{RowKey: rowKey, OwnerId: TestOwnerId, Qualifier: []byte(TestQualifier)}, RealData: types.RealDataObj{RowKey: rowKey, Data: data}}})
 	require.Nil(err, "json marshal err: %+v", err)
 	expectedValue, err := json.Marshal([]client.OutputFetchObj{{Id: rowKey, Timestamp: timestamp, Data: data}})

--- a/client/types.go
+++ b/client/types.go
@@ -36,7 +36,7 @@ type InputFetchObj struct {
 type OutputQueryObj struct {
 	Id        []byte `json:"id"`
 	Timestamp uint64 `json:"timestamp"`
-	OwnerId   string `json:"OwnerId"`
+	OwnerId   string `json:"ownerId"`
 	Qualifier string `json:"qualifier"`
 }
 

--- a/master/MasterApplication.go
+++ b/master/MasterApplication.go
@@ -193,22 +193,12 @@ func (app *MasterApplication) metaDataQuery(queryObj types.QueryObj) ([]types.Me
 	}
 
 	// create start and end for iterator
-	salt := make([]byte, 2)
-	binary.BigEndian.PutUint16(salt, 0x0000)
-	startKeyObj := types.KeyObj{Timestamp: queryObj.Start, Salt: salt}
-	endKeyObj := types.KeyObj{Timestamp: queryObj.End, Salt: salt}
+	salt := uint16(0)
 
-	startByte, err := json.Marshal(startKeyObj)
-	if err != nil {
-		return nil, errors.Wrap(err, "startKeyObj marshal err")
-	}
-	endByte, err := json.Marshal(endKeyObj)
-	if err != nil {
-		return nil, errors.Wrap(err, "endKeyObj marshal err")
-	}
+	startByte := types.GetRowKey(queryObj.Start, salt)
+	endByte := types.GetRowKey(queryObj.End, salt)
 
 	itr := app.db.IteratorColumnFamily(startByte, endByte, app.db.ColumnFamilyHandles()[consts.MetaCFNum])
-	//TODO unittest close test
 	defer itr.Close()
 
 	// time range에 해당하는 모든 데이터를 가져온다

--- a/master/MasterApplication_test.go
+++ b/master/MasterApplication_test.go
@@ -1,8 +1,6 @@
 package master_test
 
 import (
-	"encoding/binary"
-	"encoding/json"
 	"github.com/paust-team/paust-db/libs/log"
 	"github.com/paust-team/paust-db/master"
 	"github.com/paust-team/paust-db/types"
@@ -25,7 +23,6 @@ const (
 
 //test data
 var (
-	givenKeyObj1, givenKeyObj2           types.KeyObj
 	givenRowKey1, givenRowKey2           []byte
 	givenMetaDataObj1, givenMetaDataObj2 types.MetaDataObj
 	givenRealDataObj1, givenRealDataObj2 types.RealDataObj
@@ -39,25 +36,13 @@ type MasterSuite struct {
 }
 
 func (suite *MasterSuite) SetupSuite() {
-	require := suite.Require()
-
-	var err error
-
 	//test data 설정
-	timestamp1 := make([]byte, 8)
-	timestamp2 := make([]byte, 8)
-	binary.BigEndian.PutUint64(timestamp1, 1545982882435375000)
-	binary.BigEndian.PutUint64(timestamp2, 1545982882435375001)
-	salt := make([]byte, 2)
-	binary.BigEndian.PutUint16(salt, 0)
-	givenKeyObj1 = types.KeyObj{Timestamp: timestamp1, Salt: salt}
-	givenKeyObj2 = types.KeyObj{Timestamp: timestamp2, Salt: salt}
+	timestamp1 := uint64(1545982882435375000)
+	timestamp2 := uint64(1545982882435375001)
+	salt := uint16(0)
 
-	givenRowKey1, err = json.Marshal(givenKeyObj1)
-	require.Nil(err)
-
-	givenRowKey2, err = json.Marshal(givenKeyObj2)
-	require.Nil(err)
+	givenRowKey1 = types.GetRowKey(timestamp1, salt)
+	givenRowKey2 = types.GetRowKey(timestamp2, salt)
 
 	givenMetaDataObj1 = types.MetaDataObj{RowKey: givenRowKey1, OwnerId: TestOwnerId, Qualifier: []byte("Memory")}
 	givenMetaDataObj2 = types.MetaDataObj{RowKey: givenRowKey2, OwnerId: TestOwnerId2, Qualifier: []byte("Stt")}

--- a/master/MasterApplication_unit_test.go
+++ b/master/MasterApplication_unit_test.go
@@ -1,7 +1,6 @@
 package master_test
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"github.com/paust-team/paust-db/consts"
 	"github.com/paust-team/paust-db/types"
@@ -137,10 +136,8 @@ func (suite *MasterSuite) TestMasterApplication_time_only_Query() {
 
 	//when
 	emptySlice := make([]byte, 0)
-	start := make([]byte, 8)
-	end := make([]byte, 8)
-	binary.BigEndian.PutUint64(start, 1545982882435375000)
-	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	start := uint64(1545982882435375000)
+	end := uint64(1545982882435375002)
 	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerId: "", Qualifier: emptySlice}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
@@ -200,10 +197,8 @@ func (suite *MasterSuite) TestMasterApplication_qualifier_Query() {
 	*/
 
 	//when
-	start := make([]byte, 8)
-	end := make([]byte, 8)
-	binary.BigEndian.PutUint64(start, 1545982882435375000)
-	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	start := uint64(1545982882435375000)
+	end := uint64(1545982882435375002)
 	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerId: "", Qualifier: []byte("Memory")}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
@@ -266,10 +261,8 @@ func (suite *MasterSuite) TestMasterApplication_ownerId_Query() {
 
 	//when
 	emptySlice := make([]byte, 0)
-	start := make([]byte, 8)
-	end := make([]byte, 8)
-	binary.BigEndian.PutUint64(start, 1545982882435375000)
-	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	start := uint64(1545982882435375000)
+	end := uint64(1545982882435375002)
 	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerId: TestOwnerId2, Qualifier: emptySlice}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)
@@ -330,10 +323,8 @@ func (suite *MasterSuite) TestMasterApplication_both_Query() {
 	*/
 
 	//when
-	start := make([]byte, 8)
-	end := make([]byte, 8)
-	binary.BigEndian.PutUint64(start, 1545982882435375000)
-	binary.BigEndian.PutUint64(end, 1545982882435375002)
+	start := uint64(1545982882435375000)
+	end := uint64(1545982882435375002)
 	metaQueryObj := types.QueryObj{Start: start, End: end, OwnerId: TestOwnerId, Qualifier: []byte("Memory")}
 	metaQueryByteArr, err := json.Marshal(metaQueryObj)
 	require.Nil(err)

--- a/types/types.go
+++ b/types/types.go
@@ -1,10 +1,8 @@
 package types
 
-//TODO offset 추가
-type KeyObj struct {
-	Timestamp []byte `json:"timestamp"`
-	Salt      []byte `json:"salt"`
-}
+import (
+	"encoding/binary"
+)
 
 type MetaDataObj struct {
 	RowKey    []byte `json:"rowKey"`
@@ -31,4 +29,12 @@ type QueryObj struct {
 
 type FetchObj struct {
 	RowKeys [][]byte `json:"rowKeys"`
+}
+
+func GetRowKey(timestamp uint64, salt uint16) []byte {
+	rowKey := make([]byte, 10)
+	binary.BigEndian.PutUint64(rowKey[0:], timestamp)
+	binary.BigEndian.PutUint16(rowKey[8:], salt)
+
+	return rowKey
 }

--- a/types/types.go
+++ b/types/types.go
@@ -21,8 +21,8 @@ type BaseDataObj struct {
 }
 
 type QueryObj struct {
-	Start     []byte `json:"start"`
-	End       []byte `json:"end"`
+	Start     uint64 `json:"start"`
+	End       uint64 `json:"end"`
 	OwnerId   string `json:"ownerId"`
 	Qualifier []byte `json:"qualifier"`
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,21 @@
+package types_test
+
+import (
+	"encoding/binary"
+	"github.com/paust-team/paust-db/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetRowKey(t *testing.T) {
+	timestamp := uint64(1544772882435375000)
+	salt := uint16(0)
+
+	rowKey := types.GetRowKey(timestamp, salt)
+
+	ts := binary.BigEndian.Uint64(rowKey[0:8])
+	slt := binary.BigEndian.Uint16(rowKey[8:10])
+
+	require.Equal(t, timestamp, ts)
+	require.Equal(t, salt, slt)
+}


### PR DESCRIPTION
**Reference**
resolve #134 

**내용**
* timestamp(uint64), salt(uint16)을 입력받아 rowKey(byte slice, 10 byte)를 생성하는 GetRowKey 함수를 types.go에 추가
  * HTTPClient의 Put, Query function에서 rowKey를 생성시 GetRowKey 함수를 사용해 생성하도록 변경
  * HTTPClient의 deserializeKeyObj function에서 rowKey로부터 timestamp를 가져오는 과정 수정
  * MasterApplication에서 query 처리시 GetRowKey 함수를 사용해 start, end iteration key를 생성하도록 변경
* types.QueryObj의 Start, End field의 data type을 byte slice에서 uint64로 변경
  * master application에서 GetRowKey 함수를 통해 query를 위한 start, end key를 생성하기 때문