### PR TITLE
Indent query, fetch JSON response of client

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -115,7 +115,7 @@ func deSerializeKeyObj(obj []byte, isMeta bool) ([]byte, error) {
 		for _, metaDataObj := range metaDataObjs {
 			deserializedMeta = append(deserializedMeta, OutputQueryObj{Id: metaDataObj.RowKey, Timestamp: binary.BigEndian.Uint64(metaDataObj.RowKey[0:8]), OwnerId: metaDataObj.OwnerId, Qualifier: string(metaDataObj.Qualifier)})
 		}
-		deserializedObj, err := json.Marshal(deserializedMeta)
+		deserializedObj, err := json.MarshalIndent(deserializedMeta, "", "    ")
 		if err != nil {
 			return nil, errors.Wrap(err, "marshal failed")
 		}
@@ -130,7 +130,7 @@ func deSerializeKeyObj(obj []byte, isMeta bool) ([]byte, error) {
 		for _, realDataObj := range realDataObjs {
 			deserializedReal = append(deserializedReal, OutputFetchObj{Id: realDataObj.RowKey, Timestamp: binary.BigEndian.Uint64(realDataObj.RowKey[0:8]), Data: realDataObj.Data})
 		}
-		deserializedObj, err := json.Marshal(deserializedReal)
+		deserializedObj, err := json.MarshalIndent(deserializedReal, "", "    ")
 		if err != nil {
 			return nil, errors.Wrap(err, "marshal failed")
 		}


### PR DESCRIPTION
client CLI에서 출력되는 query, fetch의 JSON response data를 indent하여 이쁘게 출력하도록 변경하였습니다.

**내용**
* paust-db-client CLI에서 출력할 때의 가독성을 위해 HTTPClient 수정.
  * Client interface에서 Query, Fetch 시 Response의 Value field에 포함된 JSON 데이터를 indent하여서 marshal하도록 변경.