### PR TITLE
Change requirement version of tendermint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - sudo apt-get install -y git cmake g++ libsnappy-dev
   - git clone -b v5.17.2 https://github.com/facebook/rocksdb.git && cd rocksdb && cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF && make -j `nproc` && sudo make install && cd - && rm -rf rocksdb
   - go get -t ./master ./client ./libs/db ./libs/log
+  - cd ~/go/src/github.com/tendermint/tendermint && git checkout v0.30.2 && cd -
 
 script:
   - go test ./master ./client ./libs/db ./libs/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-get install -y git cmake g++ libsnappy-dev
   - git clone -b v5.17.2 https://github.com/facebook/rocksdb.git && cd rocksdb && cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF && make -j `nproc` && sudo make install && cd - && rm -rf rocksdb
   - go get -t ./master ./client ./libs/db ./libs/log
-  - cd ~/go/src/github.com/tendermint/tendermint && git checkout v0.30.2 && cd -
+  - cd $GOPATH/src/github.com/tendermint/tendermint && git checkout v0.30.2 && cd -
 
 script:
   - go test ./master ./client ./libs/db ./libs/log

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,15 @@ RUN rm -rf /root/rocksdb
 
 RUN ln -s /usr/local/lib64/librocksdb.so.5 /usr/local/lib/librocksdb.so.5
 
-# install paust-db
-RUN go get github.com/paust-team/paust-db/cmd/paust-db
-
-# install tendermint v0.30.0
+# install tendermint v0.30.2
 WORKDIR /go/src/github.com/tendermint/tendermint
-RUN git checkout v0.30.0
+RUN git checkout v0.30.2
 RUN make get_tools
 RUN make get_vendor_deps
 RUN make install
+
+# install paust-db
+RUN go get github.com/paust-team/paust-db/cmd/paust-db
 
 FROM alpine:3.9
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN rm -rf /root/rocksdb
 RUN ln -s /usr/local/lib64/librocksdb.so.5 /usr/local/lib/librocksdb.so.5
 
 # install tendermint v0.30.2
+RUN mkdir -p go/src/github.com/tendermint
+WORKDIR /go/src/github.com/tendermint
+RUN git clone https://github.com/tendermint/tendermint.git
 WORKDIR /go/src/github.com/tendermint/tendermint
 RUN git checkout v0.30.2
 RUN make get_tools

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirement|Version
 ---|---
 Golang | 1.11.5 or higher
 Rocksdb | 5.17.2 or higher
-Tendermint | 0.29.0 or higher
+Tendermint | 0.29.0 ~ 0.30.2
 
 ### Install go
 [Install](https://golang.org/doc/install)
@@ -70,7 +70,7 @@ $ source ~/.bash_profile
 ### Install tendermint
 ```shell
 $ cd $GOPATH/src/github.com/tendermint/tendermint
-$ git checkout v0.30.0
+$ git checkout v0.30.2
 $ make get_tools
 $ make get_vendor_deps
 $ make install


### PR DESCRIPTION
**Reference**
#150 

**내용**
* #150 에서 발생한 travis build error를 해결하기 위해 paust-db가 사용하는 tendermint version을 고정.
* 사용하는 tendermint version 범위를 0.29.0 ~ 0.30.2로 수정.
  * 해당 범위 수정에 따라 travis script와 Dockerfile 수정.